### PR TITLE
refactor: Modularize AddGift views with reusable widgets and BLoC state

### DIFF
--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_it/get_it.dart';
 
@@ -8,10 +9,28 @@ final GetIt getIt = GetIt.instance;
 
 // 앱 시작 시 호출하여 의존성을 등록
 void setupServiceLocator() {
+  final String rawBaseUrl = _readBaseUrlFromEnv();
+  final String baseUrl = _sanitizeBaseUrl(rawBaseUrl);
+  final Uri? parsedBaseUri = Uri.tryParse(baseUrl);
+  final bool isValidBaseUrl =
+      parsedBaseUri != null &&
+      parsedBaseUri.hasScheme &&
+      parsedBaseUri.host.isNotEmpty;
+
+  if (kDebugMode) {
+    debugPrint('[ServiceLocator] .env url(raw): "$rawBaseUrl"');
+    debugPrint('[ServiceLocator] .env url(normalized): "$baseUrl"');
+    if (!isValidBaseUrl) {
+      debugPrint(
+        '[ServiceLocator] 경고: API Base URL이 비어있거나 형식이 올바르지 않습니다. (.env 예시: url=https://gifo.co.kr)',
+      );
+    }
+  }
+
   // Dio 설정 (BaseUrl + LogInterceptor)
   final Dio dio = Dio(
     BaseOptions(
-      baseUrl: dotenv.env['url'] ?? '',
+      baseUrl: baseUrl,
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 10),
     ),
@@ -30,4 +49,30 @@ void setupServiceLocator() {
 
   // AddGiftApi 등록
   getIt.registerLazySingleton<AddGiftApi>(() => AddGiftApi(dio));
+}
+
+String _sanitizeBaseUrl(String rawBaseUrl) {
+  String sanitized = rawBaseUrl.trim();
+  if (sanitized.length >= 2) {
+    final bool wrappedBySingleQuotes =
+        sanitized.startsWith("'") && sanitized.endsWith("'");
+    final bool wrappedByDoubleQuotes =
+        sanitized.startsWith('"') && sanitized.endsWith('"');
+    if (wrappedBySingleQuotes || wrappedByDoubleQuotes) {
+      sanitized = sanitized.substring(1, sanitized.length - 1).trim();
+    }
+  }
+  return sanitized;
+}
+
+String _readBaseUrlFromEnv() {
+  final String direct = dotenv.env['url'] ?? '';
+  if (direct.isNotEmpty) return direct;
+
+  for (final MapEntry<String, String> entry in dotenv.env.entries) {
+    if (entry.key.trim().toLowerCase() == 'url') {
+      return entry.value;
+    }
+  }
+  return '';
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -230,55 +230,55 @@ final GoRouter appRouter = GoRouter(
         // 선물 포장 - 진입 화면 (mode=ai면 AI 소개, 아니면 직접 입력)
         GoRoute(
           path: '/addgift',
-          builder: (BuildContext context, GoRouterState state) {
+          pageBuilder: (BuildContext context, GoRouterState state) {
             final String? mode = state.uri.queryParameters['mode'];
             if (mode == 'ai') {
-              return const AiIntroView();
+              return const NoTransitionPage<void>(child: AiIntroView());
             }
-            return const ReceiverNameView();
+            return const NoTransitionPage<void>(child: ReceiverNameView());
           },
         ),
         // 선물 포장 - 추억 공유 여부 선택 화면
         GoRoute(
           path: '/addgift/memory-decision',
-          builder: (BuildContext context, GoRouterState state) =>
-              const MemoryDecisionView(),
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage<void>(child: MemoryDecisionView()),
         ),
         // 선물 포장 - 추억 갤러리 셋팅 화면 (추억 저장하는 공간)
         GoRoute(
           path: '/addgift/memory-gallery',
-          builder: (BuildContext context, GoRouterState state) =>
-              const MemoryGallerySettingView(),
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage<void>(child: MemoryGallerySettingView()),
         ),
         // 선물 포장 - 선물 전달 방식(오픈 콘텐츠) 선택 화면
         GoRoute(
           path: '/addgift/delivery-method',
-          builder: (BuildContext context, GoRouterState state) =>
-              const GiftDeliveryMethodView(),
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage<void>(child: GiftDeliveryMethodView()),
         ),
         // 선물 포장 - 가차(캡슐 뽑기) 세팅 화면
         GoRoute(
           path: '/addgift/gacha-setting',
-          builder: (BuildContext context, GoRouterState state) =>
-              const GachaSettingView(),
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage<void>(child: GachaSettingView()),
         ),
         // 선물 포장 - 퀴즈 세팅 화면
         GoRoute(
           path: '/addgift/quiz-setting',
-          builder: (BuildContext context, GoRouterState state) =>
-              const QuizSettingView(),
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage<void>(child: QuizSettingView()),
         ),
         // 선물 포장 - 바로 오픈 세팅 화면
         GoRoute(
           path: '/addgift/direct-open-setting',
-          builder: (BuildContext context, GoRouterState state) =>
-              const DirectOpenSettingView(),
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage<void>(child: DirectOpenSettingView()),
         ),
         // 선물 포장 - 등록 완료 화면
         GoRoute(
           path: '/addgift/package-complete',
-          builder: (BuildContext context, GoRouterState state) =>
-              const PackageCompleteView(),
+          pageBuilder: (BuildContext context, GoRouterState state) =>
+              const NoTransitionPage<void>(child: PackageCompleteView()),
         ),
       ],
     ),

--- a/lib/core/widgets/packaging_loading_overlay.dart
+++ b/lib/core/widgets/packaging_loading_overlay.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+// 포장하기 제출 중 전체 화면을 덮는 로딩 오버레이
+// 이미지 업로드 + 이벤트 전송 완료 전까지 표시됩니다.
+class PackagingLoadingOverlay extends StatelessWidget {
+  const PackagingLoadingOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: ColoredBox(
+        color: Colors.black.withValues(alpha: 0.55),
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 36, horizontal: 40),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+              boxShadow: <BoxShadow>[
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.15),
+                  blurRadius: 24,
+                  offset: const Offset(0, 8),
+                ),
+              ],
+            ),
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                SizedBox(
+                  width: 52,
+                  height: 52,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 4,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      Color(0xFF6DE1F1),
+                    ),
+                  ),
+                ),
+                SizedBox(height: 24),
+                Text(
+                  '선물을 포장하고 있어요...',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black87,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  '잠시만 기다려 주세요.',
+                  style: TextStyle(fontSize: 13, color: Colors.black45),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/application/gacha_setting/gacha_setting_bloc.dart
+++ b/lib/features/addgift/application/gacha_setting/gacha_setting_bloc.dart
@@ -62,8 +62,9 @@ class GachaSettingBloc extends Bloc<GachaSettingEvent, GachaSettingState> {
     );
   }
 
-  // 새 캡슐 아이템 추가: 로컬 uiItems에 추가 후 GiftPackagingBloc에 동기화
+  // 새 캡슐 아이템 추가: 로컬 uiItems에 추가 후 GiftPackagingBloc에 동기화 (최대 10개 제한)
   void _onAddItem(AddGachaItem event, Emitter<GachaSettingState> emit) {
+    if (state.uiItems.length >= 10) return;
     final DefaultGachaItemData newItem = DefaultGachaItemData(
       id: state.nextId,
       color: event.color,

--- a/lib/features/addgift/application/gift_packaging_bloc.dart
+++ b/lib/features/addgift/application/gift_packaging_bloc.dart
@@ -97,16 +97,34 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
     emit(state.copyWith(submitStatus: SubmitStatus.loading));
 
     try {
+      _logSubmitStart(event);
+
       // 1. 갤러리 이미지 업로드 (MEMORY 타입)
+      debugPrint('[GiftPackagingBloc] 1/3 갤러리 이미지 업로드 시작');
       final List<GalleryItem> uploadedGallery = await Future.wait(
-        event.gallery.map((GalleryItem item) async {
+        event.gallery.asMap().entries.map((
+          MapEntry<int, GalleryItem> entry,
+        ) async {
+          final int index = entry.key;
+          final GalleryItem item = entry.value;
+          debugPrint(
+            '[GiftPackagingBloc]   - gallery[$index] 업로드 대상: ${_shortText(item.imageUrl)}',
+          );
           final String url = await _uploadLocalImage(item.imageUrl, 'MEMORY');
+          debugPrint(
+            '[GiftPackagingBloc]   - gallery[$index] 업로드 완료: ${_shortText(url)}',
+          );
           return item.copyWith(imageUrl: url);
         }),
       );
+      debugPrint('[GiftPackagingBloc] 1/3 갤러리 이미지 업로드 완료');
 
       // 2. 콘텐츠 이미지 업로드
-      final GiftContent uploadedContent = await _uploadContentImages(event.content);
+      debugPrint('[GiftPackagingBloc] 2/3 콘텐츠 이미지 업로드 시작');
+      final GiftContent uploadedContent = await _uploadContentImages(
+        event.content,
+      );
+      debugPrint('[GiftPackagingBloc] 2/3 콘텐츠 이미지 업로드 완료');
 
       final GiftRequest request = GiftRequest(
         user: event.receiverName,
@@ -134,6 +152,7 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
       debugPrint(prettyJson);
       debugPrint('========================================');
 
+      debugPrint('[GiftPackagingBloc] 3/3 이벤트 생성 API 호출 시작 (POST /api/events)');
       final AddGiftApi api = getIt<AddGiftApi>();
       final HttpResponse<dynamic> response = await api.createGift(jsonMap);
       debugPrint(
@@ -141,22 +160,27 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
       );
 
       // 서버 응답에서 공유 URL 파싱
-      final Map<String, dynamic>? responseData =
-          response.data as Map<String, dynamic>?;
-      final Map<String, dynamic>? data =
-          responseData?['data'] as Map<String, dynamic>?;
+      final Map<String, dynamic>? responseData = _toJsonMap(response.data);
+      final Map<String, dynamic>? data = _toJsonMap(responseData?['data']);
       final String shareUrl = data?['eventUrl'] as String? ?? '';
+      if (shareUrl.isEmpty) {
+        debugPrint(
+          '[GiftPackagingBloc] 경고: 서버 응답에 eventUrl이 없습니다. raw=${response.data}',
+        );
+      }
 
       // 전송 완료: 성공 상태로 전환 (뷰에서 이 상태를 감지해 화면 전환)
-      emit(state.copyWith(
-        submitStatus: SubmitStatus.success,
-        shareUrl: shareUrl,
-      ));
+      emit(
+        state.copyWith(submitStatus: SubmitStatus.success, shareUrl: shareUrl),
+      );
+    } on DioException catch (e, stackTrace) {
+      _logDioException(e, stackTrace, stage: 'submitPackage');
+      emit(state.copyWith(submitStatus: SubmitStatus.failure));
     } catch (e, stackTrace) {
       debugPrint('========================================');
-      debugPrint('[GiftPackagingBloc] 서버 전송 중 예외 발생!');
+      debugPrint('[GiftPackagingBloc] submitPackage 단계에서 알 수 없는 예외 발생');
       debugPrint('에러 내용: $e');
-      debugPrint('스택 트레이스: \n$stackTrace');
+      debugPrint('스택 트레이스:\n$stackTrace');
       debugPrint('========================================');
 
       // 전송 실패: 실패 상태로 전환
@@ -166,7 +190,12 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
 
   // 로컬 파일 경로이면 서버에 업로드 후 URL 반환, 이미 URL이면 그대로 반환
   Future<String> _uploadLocalImage(String path, String type) async {
-    if (path.isEmpty || path.startsWith('http')) return path;
+    if (path.isEmpty || path.startsWith('http')) {
+      debugPrint(
+        '[GiftPackagingBloc] 이미지 업로드 스킵(type=$type): ${_shortText(path)}',
+      );
+      return path;
+    }
 
     final XFile xFile = XFile(path);
     final Uint8List bytes = await xFile.readAsBytes();
@@ -178,43 +207,81 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
       filename: fileName,
     );
 
+    debugPrint(
+      '[GiftPackagingBloc] 이미지 업로드 요청(type=$type, file=$fileName, bytes=${bytes.length})',
+    );
     final AddGiftApi api = getIt<AddGiftApi>();
-    final HttpResponse<dynamic> response = await api.uploadImage(type, multipartFile);
-    final Map<String, dynamic> responseData =
-        response.data as Map<String, dynamic>;
-    final Map<String, dynamic> data =
-        responseData['data'] as Map<String, dynamic>;
-    return data['imageUrl'] as String? ?? path;
+    final HttpResponse<dynamic> response = await api.uploadImage(
+      type,
+      multipartFile,
+    );
+    final Map<String, dynamic>? responseData = _toJsonMap(response.data);
+    final Map<String, dynamic>? data = _toJsonMap(responseData?['data']);
+    final String uploadedUrl = data?['imageUrl'] as String? ?? path;
+    debugPrint(
+      '[GiftPackagingBloc] 이미지 업로드 응답(type=$type, status=${response.response.statusCode}) -> ${_shortText(uploadedUrl)}',
+    );
+    return uploadedUrl;
   }
 
   // 콘텐츠 타입별 이미지 업로드 후 URL이 교체된 GiftContent 반환
   Future<GiftContent> _uploadContentImages(GiftContent content) async {
     if (content.gacha != null) {
       final GachaContent gacha = content.gacha!;
+      debugPrint(
+        '[GiftPackagingBloc] 콘텐츠 타입: gacha (아이템 ${gacha.list.length}개)',
+      );
       final List<GachaItem> uploadedItems = await Future.wait(
-        gacha.list.map((GachaItem item) async {
+        gacha.list.asMap().entries.map((MapEntry<int, GachaItem> entry) async {
+          final int index = entry.key;
+          final GachaItem item = entry.value;
+          debugPrint(
+            '[GiftPackagingBloc]   - gacha[$index] 업로드 대상: ${_shortText(item.imageUrl)}',
+          );
           final String url = await _uploadLocalImage(item.imageUrl, 'GIFT');
+          debugPrint(
+            '[GiftPackagingBloc]   - gacha[$index] 업로드 완료: ${_shortText(url)}',
+          );
           return item.copyWith(imageUrl: url);
         }),
       );
-      return content.copyWith(
-        gacha: gacha.copyWith(list: uploadedItems),
-      );
+      return content.copyWith(gacha: gacha.copyWith(list: uploadedItems));
     }
 
     if (content.quiz != null) {
       final QuizContent quiz = content.quiz!;
+      debugPrint('[GiftPackagingBloc] 콘텐츠 타입: quiz (문제 ${quiz.list.length}개)');
       final List<QuizItemModel> uploadedItems = await Future.wait(
-        quiz.list.map((QuizItemModel item) async {
+        quiz.list.asMap().entries.map((
+          MapEntry<int, QuizItemModel> entry,
+        ) async {
+          final int index = entry.key;
+          final QuizItemModel item = entry.value;
           if (item.imageUrl == null || item.imageUrl!.isEmpty) return item;
+          debugPrint(
+            '[GiftPackagingBloc]   - quiz[$index] 업로드 대상: ${_shortText(item.imageUrl!)}',
+          );
           final String url = await _uploadLocalImage(item.imageUrl!, 'QUIZ');
+          debugPrint(
+            '[GiftPackagingBloc]   - quiz[$index] 업로드 완료: ${_shortText(url)}',
+          );
           return item.copyWith(imageUrl: url);
         }),
       );
-      final String successUrl =
-          await _uploadLocalImage(quiz.successReward.imageUrl, 'QUIZ');
-      final String failUrl =
-          await _uploadLocalImage(quiz.failReward.imageUrl, 'QUIZ');
+      debugPrint(
+        '[GiftPackagingBloc]   - successReward 업로드 대상: ${_shortText(quiz.successReward.imageUrl)}',
+      );
+      final String successUrl = await _uploadLocalImage(
+        quiz.successReward.imageUrl,
+        'QUIZ',
+      );
+      debugPrint(
+        '[GiftPackagingBloc]   - failReward 업로드 대상: ${_shortText(quiz.failReward.imageUrl)}',
+      );
+      final String failUrl = await _uploadLocalImage(
+        quiz.failReward.imageUrl,
+        'QUIZ',
+      );
       return content.copyWith(
         quiz: quiz.copyWith(
           list: uploadedItems,
@@ -226,10 +293,15 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
 
     if (content.unboxing != null) {
       final UnboxingContent unboxing = content.unboxing!;
-      final String beforeUrl =
-          await _uploadLocalImage(unboxing.beforeOpen.imageUrl, 'GIFT');
-      final String afterUrl =
-          await _uploadLocalImage(unboxing.afterOpen.imageUrl, 'GIFT');
+      debugPrint('[GiftPackagingBloc] 콘텐츠 타입: unboxing');
+      final String beforeUrl = await _uploadLocalImage(
+        unboxing.beforeOpen.imageUrl,
+        'GIFT',
+      );
+      final String afterUrl = await _uploadLocalImage(
+        unboxing.afterOpen.imageUrl,
+        'GIFT',
+      );
       return content.copyWith(
         unboxing: unboxing.copyWith(
           beforeOpen: unboxing.beforeOpen.copyWith(imageUrl: beforeUrl),
@@ -239,6 +311,61 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
     }
 
     return content;
+  }
+
+  void _logSubmitStart(SubmitPackage event) {
+    debugPrint('========================================');
+    debugPrint('[GiftPackagingBloc] submitPackage 시작');
+    debugPrint('receiverName: "${event.receiverName}"');
+    debugPrint('subTitle: "${event.subTitle}"');
+    debugPrint('bgm: "${event.bgm}"');
+    debugPrint('galleryCount: ${event.gallery.length}');
+    debugPrint('contentType: ${_contentTypeLabel(event.content)}');
+    debugPrint('========================================');
+  }
+
+  void _logDioException(
+    DioException e,
+    StackTrace stackTrace, {
+    required String stage,
+  }) {
+    debugPrint('========================================');
+    debugPrint('[GiftPackagingBloc] $stage 단계에서 DioException 발생');
+    debugPrint('type: ${e.type}');
+    debugPrint('message: ${e.message}');
+    debugPrint('request: ${e.requestOptions.method} ${e.requestOptions.uri}');
+    debugPrint('query: ${e.requestOptions.queryParameters}');
+    debugPrint('requestBody: ${e.requestOptions.data}');
+    if (e.response != null) {
+      debugPrint('statusCode: ${e.response?.statusCode}');
+      debugPrint('responseBody: ${e.response?.data}');
+      debugPrint('responseHeaders: ${e.response?.headers.map}');
+    }
+    debugPrint('stackTrace:\n$stackTrace');
+    debugPrint('========================================');
+  }
+
+  Map<String, dynamic>? _toJsonMap(dynamic value) {
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) {
+      return value.map(
+        (dynamic key, dynamic mapValue) =>
+            MapEntry<String, dynamic>(key.toString(), mapValue),
+      );
+    }
+    return null;
+  }
+
+  String _contentTypeLabel(GiftContent content) {
+    if (content.gacha != null) return 'gacha';
+    if (content.quiz != null) return 'quiz';
+    if (content.unboxing != null) return 'unboxing';
+    return 'unknown';
+  }
+
+  String _shortText(String value) {
+    if (value.length <= 120) return value;
+    return '${value.substring(0, 117)}...';
   }
 
   void _onResetPackaging(

--- a/lib/features/addgift/application/gift_packaging_bloc.dart
+++ b/lib/features/addgift/application/gift_packaging_bloc.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:retrofit/dio.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:retrofit/dio.dart' show HttpResponse;
 
 import '../../../core/di/service_locator.dart';
 import '../model/gacha_content.dart';
@@ -86,7 +88,7 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
     emit(state.copyWith(unboxingContent: event.unboxing));
   }
 
-  // --- 포장 완료: 이벤트에 담긴 데이터로 GiftRequest 조립 후 서버 전송 ---
+  // --- 포장 완료: 이미지 업로드 후 이벤트 데이터를 조립하여 서버 전송 ---
   Future<void> _onSubmitPackage(
     SubmitPackage event,
     Emitter<GiftPackagingState> emit,
@@ -94,55 +96,60 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
     // 전송 시작: 로딩 상태로 전환
     emit(state.copyWith(submitStatus: SubmitStatus.loading));
 
-    final GiftRequest request = GiftRequest(
-      user: event.receiverName,
-      subTitle: event.subTitle,
-      bgm: event.bgm,
-      gallery: event.gallery,
-      content: event.content,
-    );
-
-    // JSON 변환 후 로그 출력
-    final Map<String, dynamic> jsonMap = request.toJson();
-
-    // null content 필드 제거 (Freezed는 nullable 필드를 null로 직렬화하므로)
-    final Map<String, dynamic>? contentMap =
-        jsonMap['content'] as Map<String, dynamic>?;
-    if (contentMap != null) {
-      contentMap.removeWhere((String key, dynamic value) => value == null);
-    }
-
-    final String prettyJson = const JsonEncoder.withIndent(
-      '  ',
-    ).convert(jsonMap);
-    debugPrint('========================================');
-    debugPrint('[GiftPackagingBloc] 선물 포장 완료 - 서버 전송 데이터:');
-    debugPrint(prettyJson);
-    debugPrint('========================================');
-
     try {
+      // 1. 갤러리 이미지 업로드 (MEMORY 타입)
+      final List<GalleryItem> uploadedGallery = await Future.wait(
+        event.gallery.map((GalleryItem item) async {
+          final String url = await _uploadLocalImage(item.imageUrl, 'MEMORY');
+          return item.copyWith(imageUrl: url);
+        }),
+      );
+
+      // 2. 콘텐츠 이미지 업로드
+      final GiftContent uploadedContent = await _uploadContentImages(event.content);
+
+      final GiftRequest request = GiftRequest(
+        user: event.receiverName,
+        subTitle: event.subTitle,
+        bgm: event.bgm,
+        gallery: uploadedGallery,
+        content: uploadedContent,
+      );
+
+      // JSON 변환 후 로그 출력
+      final Map<String, dynamic> jsonMap = request.toJson();
+
+      // null content 필드 제거 (Freezed는 nullable 필드를 null로 직렬화하므로)
+      final Map<String, dynamic>? contentMap =
+          jsonMap['content'] as Map<String, dynamic>?;
+      if (contentMap != null) {
+        contentMap.removeWhere((String key, dynamic value) => value == null);
+      }
+
+      final String prettyJson = const JsonEncoder.withIndent(
+        '  ',
+      ).convert(jsonMap);
+      debugPrint('========================================');
+      debugPrint('[GiftPackagingBloc] 선물 포장 완료 - 서버 전송 데이터:');
+      debugPrint(prettyJson);
+      debugPrint('========================================');
+
       final AddGiftApi api = getIt<AddGiftApi>();
       final HttpResponse<dynamic> response = await api.createGift(jsonMap);
       debugPrint(
         '[GiftPackagingBloc] 서버 전송 성공! (상태 코드: ${response.response.statusCode})',
       );
 
-      // 서버 응답에서 공유 코드 파싱 (필드명 미확정으로 방어 파싱)
+      // 서버 응답에서 공유 URL 파싱
       final Map<String, dynamic>? responseData =
           response.data as Map<String, dynamic>?;
-      final String shareCode =
-          responseData?['invite_code'] as String? ??
-          responseData?['code'] as String? ??
-          responseData?['share_code'] as String? ??
-          '';
-      final String shareUrl = shareCode.isNotEmpty
-          ? Uri.base.resolve('/gift/code/$shareCode').toString()
-          : responseData?['share_url'] as String? ?? '';
+      final Map<String, dynamic>? data =
+          responseData?['data'] as Map<String, dynamic>?;
+      final String shareUrl = data?['eventUrl'] as String? ?? '';
 
       // 전송 완료: 성공 상태로 전환 (뷰에서 이 상태를 감지해 화면 전환)
       emit(state.copyWith(
         submitStatus: SubmitStatus.success,
-        shareCode: shareCode,
         shareUrl: shareUrl,
       ));
     } catch (e, stackTrace) {
@@ -150,16 +157,88 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
       debugPrint('[GiftPackagingBloc] 서버 전송 중 예외 발생!');
       debugPrint('에러 내용: $e');
       debugPrint('스택 트레이스: \n$stackTrace');
-
-      final String errorStr = e.toString();
-      if (errorStr.contains('statusCode')) {
-        debugPrint('[GiftPackagingBloc] 상세 에러 (StatusCode 포함): $errorStr');
-      }
       debugPrint('========================================');
 
       // 전송 실패: 실패 상태로 전환
       emit(state.copyWith(submitStatus: SubmitStatus.failure));
     }
+  }
+
+  // 로컬 파일 경로이면 서버에 업로드 후 URL 반환, 이미 URL이면 그대로 반환
+  Future<String> _uploadLocalImage(String path, String type) async {
+    if (path.isEmpty || path.startsWith('http')) return path;
+
+    final XFile xFile = XFile(path);
+    final Uint8List bytes = await xFile.readAsBytes();
+    final String rawName = path.split('/').last.split('?').first;
+    final String fileName = rawName.isEmpty ? 'image.jpg' : rawName;
+
+    final MultipartFile multipartFile = MultipartFile.fromBytes(
+      bytes,
+      filename: fileName,
+    );
+
+    final AddGiftApi api = getIt<AddGiftApi>();
+    final HttpResponse<dynamic> response = await api.uploadImage(type, multipartFile);
+    final Map<String, dynamic> responseData =
+        response.data as Map<String, dynamic>;
+    final Map<String, dynamic> data =
+        responseData['data'] as Map<String, dynamic>;
+    return data['imageUrl'] as String? ?? path;
+  }
+
+  // 콘텐츠 타입별 이미지 업로드 후 URL이 교체된 GiftContent 반환
+  Future<GiftContent> _uploadContentImages(GiftContent content) async {
+    if (content.gacha != null) {
+      final GachaContent gacha = content.gacha!;
+      final List<GachaItem> uploadedItems = await Future.wait(
+        gacha.list.map((GachaItem item) async {
+          final String url = await _uploadLocalImage(item.imageUrl, 'GIFT');
+          return item.copyWith(imageUrl: url);
+        }),
+      );
+      return content.copyWith(
+        gacha: gacha.copyWith(list: uploadedItems),
+      );
+    }
+
+    if (content.quiz != null) {
+      final QuizContent quiz = content.quiz!;
+      final List<QuizItemModel> uploadedItems = await Future.wait(
+        quiz.list.map((QuizItemModel item) async {
+          if (item.imageUrl == null || item.imageUrl!.isEmpty) return item;
+          final String url = await _uploadLocalImage(item.imageUrl!, 'QUIZ');
+          return item.copyWith(imageUrl: url);
+        }),
+      );
+      final String successUrl =
+          await _uploadLocalImage(quiz.successReward.imageUrl, 'QUIZ');
+      final String failUrl =
+          await _uploadLocalImage(quiz.failReward.imageUrl, 'QUIZ');
+      return content.copyWith(
+        quiz: quiz.copyWith(
+          list: uploadedItems,
+          successReward: quiz.successReward.copyWith(imageUrl: successUrl),
+          failReward: quiz.failReward.copyWith(imageUrl: failUrl),
+        ),
+      );
+    }
+
+    if (content.unboxing != null) {
+      final UnboxingContent unboxing = content.unboxing!;
+      final String beforeUrl =
+          await _uploadLocalImage(unboxing.beforeOpen.imageUrl, 'GIFT');
+      final String afterUrl =
+          await _uploadLocalImage(unboxing.afterOpen.imageUrl, 'GIFT');
+      return content.copyWith(
+        unboxing: unboxing.copyWith(
+          beforeOpen: unboxing.beforeOpen.copyWith(imageUrl: beforeUrl),
+          afterOpen: unboxing.afterOpen.copyWith(imageUrl: afterUrl),
+        ),
+      );
+    }
+
+    return content;
   }
 
   void _onResetPackaging(

--- a/lib/features/addgift/application/gift_packaging_bloc.dart
+++ b/lib/features/addgift/application/gift_packaging_bloc.dart
@@ -138,10 +138,10 @@ class GiftPackagingBloc extends Bloc<GiftPackagingEvent, GiftPackagingState> {
       final Map<String, dynamic> jsonMap = request.toJson();
 
       // null content 필드 제거 (Freezed는 nullable 필드를 null로 직렬화하므로)
-      final Map<String, dynamic>? contentMap =
-          jsonMap['content'] as Map<String, dynamic>?;
+      final Map<String, dynamic>? contentMap = _toJsonMap(jsonMap['content']);
       if (contentMap != null) {
         contentMap.removeWhere((String key, dynamic value) => value == null);
+        jsonMap['content'] = contentMap;
       }
 
       final String prettyJson = const JsonEncoder.withIndent(

--- a/lib/features/addgift/application/memory_gallery_setting/memory_gallery_setting_bloc.dart
+++ b/lib/features/addgift/application/memory_gallery_setting/memory_gallery_setting_bloc.dart
@@ -57,11 +57,12 @@ class MemoryGallerySettingBloc
     );
   }
 
-  // 새 갤러리 아이템 추가 후 GiftPackagingBloc에 동기화
+  // 새 갤러리 아이템 추가 후 GiftPackagingBloc에 동기화 (최대 10개 제한)
   void _onAddItem(
     AddMemoryItem event,
     Emitter<MemoryGallerySettingState> emit,
   ) {
+    if (state.uiItems.length >= 10) return;
     final MemoryGalleryItemData newItem = MemoryGalleryItemData(id: state.nextId);
     final List<MemoryGalleryItemData> newUiItems = List<MemoryGalleryItemData>.from(state.uiItems)
       ..add(newItem);

--- a/lib/features/addgift/application/quiz_setting/quiz_setting_state.dart
+++ b/lib/features/addgift/application/quiz_setting/quiz_setting_state.dart
@@ -15,6 +15,15 @@ class QuizSettingState {
         successReward = successReward ?? QuizRewardData(requiredCount: 1),
         failReward = failReward ?? QuizRewardData();
 
+  // 현재 등록된 이미지 수 (질문 이미지 + 성공/실패 보상 이미지)
+  int get imageCount {
+    final int itemImages =
+        uiItems.where((QuizItemData item) => item.imageFile != null).length;
+    final int successImage = successReward.imageFile != null ? 1 : 0;
+    final int failImage = failReward.imageFile != null ? 1 : 0;
+    return itemImages + successImage + failImage;
+  }
+
   QuizSettingState copyWith({
     List<QuizItemData>? uiItems,
     QuizRewardData? successReward,

--- a/lib/features/addgift/model/gacha_content.dart
+++ b/lib/features/addgift/model/gacha_content.dart
@@ -7,6 +7,8 @@ part 'gacha_content.g.dart';
 
 @freezed
 abstract class GachaContent with _$GachaContent {
+  // ignore: invalid_annotation_target
+  @JsonSerializable(explicitToJson: true)
   const factory GachaContent({
     @JsonKey(name: 'play_count') @Default(3) int playCount,
     @Default(<GachaItem>[]) List<GachaItem> list,

--- a/lib/features/addgift/model/gacha_content.freezed.dart
+++ b/lib/features/addgift/model/gacha_content.freezed.dart
@@ -207,8 +207,8 @@ return $default(_that.playCount,_that.list);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _GachaContent implements GachaContent {
   const _GachaContent({@JsonKey(name: 'play_count') this.playCount = 3, final  List<GachaItem> list = const <GachaItem>[]}): _list = list;
   factory _GachaContent.fromJson(Map<String, dynamic> json) => _$GachaContentFromJson(json);

--- a/lib/features/addgift/model/gacha_content.g.dart
+++ b/lib/features/addgift/model/gacha_content.g.dart
@@ -17,7 +17,10 @@ _GachaContent _$GachaContentFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$GachaContentToJson(_GachaContent instance) =>
-    <String, dynamic>{'play_count': instance.playCount, 'list': instance.list};
+    <String, dynamic>{
+      'play_count': instance.playCount,
+      'list': instance.list.map((e) => e.toJson()).toList(),
+    };
 
 _GachaItem _$GachaItemFromJson(Map<String, dynamic> json) => _GachaItem(
   itemName: json['item_name'] as String? ?? '',

--- a/lib/features/addgift/model/gift_content.dart
+++ b/lib/features/addgift/model/gift_content.dart
@@ -11,6 +11,8 @@ part 'gift_content.g.dart';
 // 실제 전송 시 선택된 콘텐츠만 non-null
 @freezed
 abstract class GiftContent with _$GiftContent {
+  // ignore: invalid_annotation_target
+  @JsonSerializable(explicitToJson: true)
   const factory GiftContent({
     GachaContent? gacha,
     QuizContent? quiz,

--- a/lib/features/addgift/model/gift_content.freezed.dart
+++ b/lib/features/addgift/model/gift_content.freezed.dart
@@ -244,8 +244,8 @@ return $default(_that.gacha,_that.quiz,_that.unboxing);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _GiftContent implements GiftContent {
   const _GiftContent({this.gacha, this.quiz, this.unboxing});
   factory _GiftContent.fromJson(Map<String, dynamic> json) => _$GiftContentFromJson(json);

--- a/lib/features/addgift/model/gift_content.g.dart
+++ b/lib/features/addgift/model/gift_content.g.dart
@@ -20,7 +20,7 @@ _GiftContent _$GiftContentFromJson(Map<String, dynamic> json) => _GiftContent(
 
 Map<String, dynamic> _$GiftContentToJson(_GiftContent instance) =>
     <String, dynamic>{
-      'gacha': instance.gacha,
-      'quiz': instance.quiz,
-      'unboxing': instance.unboxing,
+      'gacha': instance.gacha?.toJson(),
+      'quiz': instance.quiz?.toJson(),
+      'unboxing': instance.unboxing?.toJson(),
     };

--- a/lib/features/addgift/model/gift_request.dart
+++ b/lib/features/addgift/model/gift_request.dart
@@ -13,7 +13,11 @@ abstract class GiftRequest with _$GiftRequest {
     @Default('') String user,
     @JsonKey(name: 'sub_title') @Default('') String subTitle,
     @Default('') String bgm,
+    @Default('') String password,
+    @JsonKey(name: 'sender_name') @Default('') String senderName,
     @Default(<GalleryItem>[]) List<GalleryItem> gallery,
+    @JsonKey(name: 'uploaded_bgm_urls') @Default(<String>[]) List<String> uploadedBgmUrls,
+    @JsonKey(name: 'expired_at', includeIfNull: false) String? expiredAt,
     required GiftContent content,
   }) = _GiftRequest;
 

--- a/lib/features/addgift/model/gift_request.dart
+++ b/lib/features/addgift/model/gift_request.dart
@@ -9,6 +9,8 @@ part 'gift_request.g.dart';
 // 서버에 전송할 최상위 요청 모델
 @freezed
 abstract class GiftRequest with _$GiftRequest {
+  // ignore: invalid_annotation_target
+  @JsonSerializable(explicitToJson: true)
   const factory GiftRequest({
     @Default('') String user,
     @JsonKey(name: 'sub_title') @Default('') String subTitle,
@@ -16,7 +18,9 @@ abstract class GiftRequest with _$GiftRequest {
     @Default('') String password,
     @JsonKey(name: 'sender_name') @Default('') String senderName,
     @Default(<GalleryItem>[]) List<GalleryItem> gallery,
-    @JsonKey(name: 'uploaded_bgm_urls') @Default(<String>[]) List<String> uploadedBgmUrls,
+    @JsonKey(name: 'uploaded_bgm_urls')
+    @Default(<String>[])
+    List<String> uploadedBgmUrls,
     @JsonKey(name: 'expired_at', includeIfNull: false) String? expiredAt,
     required GiftContent content,
   }) = _GiftRequest;

--- a/lib/features/addgift/model/gift_request.freezed.dart
+++ b/lib/features/addgift/model/gift_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GiftRequest {
 
- String get user;@JsonKey(name: 'sub_title') String get subTitle; String get bgm; List<GalleryItem> get gallery; GiftContent get content;
+ String get user;@JsonKey(name: 'sub_title') String get subTitle; String get bgm; String get password;@JsonKey(name: 'sender_name') String get senderName; List<GalleryItem> get gallery;@JsonKey(name: 'uploaded_bgm_urls') List<String> get uploadedBgmUrls;@JsonKey(name: 'expired_at', includeIfNull: false) String? get expiredAt; GiftContent get content;
 /// Create a copy of GiftRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $GiftRequestCopyWith<GiftRequest> get copyWith => _$GiftRequestCopyWithImpl<Gift
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GiftRequest&&(identical(other.user, user) || other.user == user)&&(identical(other.subTitle, subTitle) || other.subTitle == subTitle)&&(identical(other.bgm, bgm) || other.bgm == bgm)&&const DeepCollectionEquality().equals(other.gallery, gallery)&&(identical(other.content, content) || other.content == content));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GiftRequest&&(identical(other.user, user) || other.user == user)&&(identical(other.subTitle, subTitle) || other.subTitle == subTitle)&&(identical(other.bgm, bgm) || other.bgm == bgm)&&(identical(other.password, password) || other.password == password)&&(identical(other.senderName, senderName) || other.senderName == senderName)&&const DeepCollectionEquality().equals(other.gallery, gallery)&&const DeepCollectionEquality().equals(other.uploadedBgmUrls, uploadedBgmUrls)&&(identical(other.expiredAt, expiredAt) || other.expiredAt == expiredAt)&&(identical(other.content, content) || other.content == content));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,user,subTitle,bgm,const DeepCollectionEquality().hash(gallery),content);
+int get hashCode => Object.hash(runtimeType,user,subTitle,bgm,password,senderName,const DeepCollectionEquality().hash(gallery),const DeepCollectionEquality().hash(uploadedBgmUrls),expiredAt,content);
 
 @override
 String toString() {
-  return 'GiftRequest(user: $user, subTitle: $subTitle, bgm: $bgm, gallery: $gallery, content: $content)';
+  return 'GiftRequest(user: $user, subTitle: $subTitle, bgm: $bgm, password: $password, senderName: $senderName, gallery: $gallery, uploadedBgmUrls: $uploadedBgmUrls, expiredAt: $expiredAt, content: $content)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $GiftRequestCopyWith<$Res>  {
   factory $GiftRequestCopyWith(GiftRequest value, $Res Function(GiftRequest) _then) = _$GiftRequestCopyWithImpl;
 @useResult
 $Res call({
- String user,@JsonKey(name: 'sub_title') String subTitle, String bgm, List<GalleryItem> gallery, GiftContent content
+ String user,@JsonKey(name: 'sub_title') String subTitle, String bgm, String password,@JsonKey(name: 'sender_name') String senderName, List<GalleryItem> gallery,@JsonKey(name: 'uploaded_bgm_urls') List<String> uploadedBgmUrls,@JsonKey(name: 'expired_at', includeIfNull: false) String? expiredAt, GiftContent content
 });
 
 
@@ -65,13 +65,17 @@ class _$GiftRequestCopyWithImpl<$Res>
 
 /// Create a copy of GiftRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? subTitle = null,Object? bgm = null,Object? gallery = null,Object? content = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? subTitle = null,Object? bgm = null,Object? password = null,Object? senderName = null,Object? gallery = null,Object? uploadedBgmUrls = null,Object? expiredAt = freezed,Object? content = null,}) {
   return _then(_self.copyWith(
 user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
 as String,subTitle: null == subTitle ? _self.subTitle : subTitle // ignore: cast_nullable_to_non_nullable
 as String,bgm: null == bgm ? _self.bgm : bgm // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,senderName: null == senderName ? _self.senderName : senderName // ignore: cast_nullable_to_non_nullable
 as String,gallery: null == gallery ? _self.gallery : gallery // ignore: cast_nullable_to_non_nullable
-as List<GalleryItem>,content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
+as List<GalleryItem>,uploadedBgmUrls: null == uploadedBgmUrls ? _self.uploadedBgmUrls : uploadedBgmUrls // ignore: cast_nullable_to_non_nullable
+as List<String>,expiredAt: freezed == expiredAt ? _self.expiredAt : expiredAt // ignore: cast_nullable_to_non_nullable
+as String?,content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
 as GiftContent,
   ));
 }
@@ -166,10 +170,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String user, @JsonKey(name: 'sub_title')  String subTitle,  String bgm,  List<GalleryItem> gallery,  GiftContent content)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String user, @JsonKey(name: 'sub_title')  String subTitle,  String bgm,  String password, @JsonKey(name: 'sender_name')  String senderName,  List<GalleryItem> gallery, @JsonKey(name: 'uploaded_bgm_urls')  List<String> uploadedBgmUrls, @JsonKey(name: 'expired_at', includeIfNull: false)  String? expiredAt,  GiftContent content)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GiftRequest() when $default != null:
-return $default(_that.user,_that.subTitle,_that.bgm,_that.gallery,_that.content);case _:
+return $default(_that.user,_that.subTitle,_that.bgm,_that.password,_that.senderName,_that.gallery,_that.uploadedBgmUrls,_that.expiredAt,_that.content);case _:
   return orElse();
 
 }
@@ -187,10 +191,10 @@ return $default(_that.user,_that.subTitle,_that.bgm,_that.gallery,_that.content)
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String user, @JsonKey(name: 'sub_title')  String subTitle,  String bgm,  List<GalleryItem> gallery,  GiftContent content)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String user, @JsonKey(name: 'sub_title')  String subTitle,  String bgm,  String password, @JsonKey(name: 'sender_name')  String senderName,  List<GalleryItem> gallery, @JsonKey(name: 'uploaded_bgm_urls')  List<String> uploadedBgmUrls, @JsonKey(name: 'expired_at', includeIfNull: false)  String? expiredAt,  GiftContent content)  $default,) {final _that = this;
 switch (_that) {
 case _GiftRequest():
-return $default(_that.user,_that.subTitle,_that.bgm,_that.gallery,_that.content);case _:
+return $default(_that.user,_that.subTitle,_that.bgm,_that.password,_that.senderName,_that.gallery,_that.uploadedBgmUrls,_that.expiredAt,_that.content);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -207,10 +211,10 @@ return $default(_that.user,_that.subTitle,_that.bgm,_that.gallery,_that.content)
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String user, @JsonKey(name: 'sub_title')  String subTitle,  String bgm,  List<GalleryItem> gallery,  GiftContent content)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String user, @JsonKey(name: 'sub_title')  String subTitle,  String bgm,  String password, @JsonKey(name: 'sender_name')  String senderName,  List<GalleryItem> gallery, @JsonKey(name: 'uploaded_bgm_urls')  List<String> uploadedBgmUrls, @JsonKey(name: 'expired_at', includeIfNull: false)  String? expiredAt,  GiftContent content)?  $default,) {final _that = this;
 switch (_that) {
 case _GiftRequest() when $default != null:
-return $default(_that.user,_that.subTitle,_that.bgm,_that.gallery,_that.content);case _:
+return $default(_that.user,_that.subTitle,_that.bgm,_that.password,_that.senderName,_that.gallery,_that.uploadedBgmUrls,_that.expiredAt,_that.content);case _:
   return null;
 
 }
@@ -222,12 +226,14 @@ return $default(_that.user,_that.subTitle,_that.bgm,_that.gallery,_that.content)
 @JsonSerializable()
 
 class _GiftRequest implements GiftRequest {
-  const _GiftRequest({this.user = '', @JsonKey(name: 'sub_title') this.subTitle = '', this.bgm = '', final  List<GalleryItem> gallery = const <GalleryItem>[], required this.content}): _gallery = gallery;
+  const _GiftRequest({this.user = '', @JsonKey(name: 'sub_title') this.subTitle = '', this.bgm = '', this.password = '', @JsonKey(name: 'sender_name') this.senderName = '', final  List<GalleryItem> gallery = const <GalleryItem>[], @JsonKey(name: 'uploaded_bgm_urls') final  List<String> uploadedBgmUrls = const <String>[], @JsonKey(name: 'expired_at', includeIfNull: false) this.expiredAt, required this.content}): _gallery = gallery,_uploadedBgmUrls = uploadedBgmUrls;
   factory _GiftRequest.fromJson(Map<String, dynamic> json) => _$GiftRequestFromJson(json);
 
 @override@JsonKey() final  String user;
 @override@JsonKey(name: 'sub_title') final  String subTitle;
 @override@JsonKey() final  String bgm;
+@override@JsonKey() final  String password;
+@override@JsonKey(name: 'sender_name') final  String senderName;
  final  List<GalleryItem> _gallery;
 @override@JsonKey() List<GalleryItem> get gallery {
   if (_gallery is EqualUnmodifiableListView) return _gallery;
@@ -235,6 +241,14 @@ class _GiftRequest implements GiftRequest {
   return EqualUnmodifiableListView(_gallery);
 }
 
+ final  List<String> _uploadedBgmUrls;
+@override@JsonKey(name: 'uploaded_bgm_urls') List<String> get uploadedBgmUrls {
+  if (_uploadedBgmUrls is EqualUnmodifiableListView) return _uploadedBgmUrls;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_uploadedBgmUrls);
+}
+
+@override@JsonKey(name: 'expired_at', includeIfNull: false) final  String? expiredAt;
 @override final  GiftContent content;
 
 /// Create a copy of GiftRequest
@@ -250,16 +264,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GiftRequest&&(identical(other.user, user) || other.user == user)&&(identical(other.subTitle, subTitle) || other.subTitle == subTitle)&&(identical(other.bgm, bgm) || other.bgm == bgm)&&const DeepCollectionEquality().equals(other._gallery, _gallery)&&(identical(other.content, content) || other.content == content));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GiftRequest&&(identical(other.user, user) || other.user == user)&&(identical(other.subTitle, subTitle) || other.subTitle == subTitle)&&(identical(other.bgm, bgm) || other.bgm == bgm)&&(identical(other.password, password) || other.password == password)&&(identical(other.senderName, senderName) || other.senderName == senderName)&&const DeepCollectionEquality().equals(other._gallery, _gallery)&&const DeepCollectionEquality().equals(other._uploadedBgmUrls, _uploadedBgmUrls)&&(identical(other.expiredAt, expiredAt) || other.expiredAt == expiredAt)&&(identical(other.content, content) || other.content == content));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,user,subTitle,bgm,const DeepCollectionEquality().hash(_gallery),content);
+int get hashCode => Object.hash(runtimeType,user,subTitle,bgm,password,senderName,const DeepCollectionEquality().hash(_gallery),const DeepCollectionEquality().hash(_uploadedBgmUrls),expiredAt,content);
 
 @override
 String toString() {
-  return 'GiftRequest(user: $user, subTitle: $subTitle, bgm: $bgm, gallery: $gallery, content: $content)';
+  return 'GiftRequest(user: $user, subTitle: $subTitle, bgm: $bgm, password: $password, senderName: $senderName, gallery: $gallery, uploadedBgmUrls: $uploadedBgmUrls, expiredAt: $expiredAt, content: $content)';
 }
 
 
@@ -270,7 +284,7 @@ abstract mixin class _$GiftRequestCopyWith<$Res> implements $GiftRequestCopyWith
   factory _$GiftRequestCopyWith(_GiftRequest value, $Res Function(_GiftRequest) _then) = __$GiftRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String user,@JsonKey(name: 'sub_title') String subTitle, String bgm, List<GalleryItem> gallery, GiftContent content
+ String user,@JsonKey(name: 'sub_title') String subTitle, String bgm, String password,@JsonKey(name: 'sender_name') String senderName, List<GalleryItem> gallery,@JsonKey(name: 'uploaded_bgm_urls') List<String> uploadedBgmUrls,@JsonKey(name: 'expired_at', includeIfNull: false) String? expiredAt, GiftContent content
 });
 
 
@@ -287,13 +301,17 @@ class __$GiftRequestCopyWithImpl<$Res>
 
 /// Create a copy of GiftRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? subTitle = null,Object? bgm = null,Object? gallery = null,Object? content = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? subTitle = null,Object? bgm = null,Object? password = null,Object? senderName = null,Object? gallery = null,Object? uploadedBgmUrls = null,Object? expiredAt = freezed,Object? content = null,}) {
   return _then(_GiftRequest(
 user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
 as String,subTitle: null == subTitle ? _self.subTitle : subTitle // ignore: cast_nullable_to_non_nullable
 as String,bgm: null == bgm ? _self.bgm : bgm // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,senderName: null == senderName ? _self.senderName : senderName // ignore: cast_nullable_to_non_nullable
 as String,gallery: null == gallery ? _self._gallery : gallery // ignore: cast_nullable_to_non_nullable
-as List<GalleryItem>,content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
+as List<GalleryItem>,uploadedBgmUrls: null == uploadedBgmUrls ? _self._uploadedBgmUrls : uploadedBgmUrls // ignore: cast_nullable_to_non_nullable
+as List<String>,expiredAt: freezed == expiredAt ? _self.expiredAt : expiredAt // ignore: cast_nullable_to_non_nullable
+as String?,content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
 as GiftContent,
   ));
 }

--- a/lib/features/addgift/model/gift_request.freezed.dart
+++ b/lib/features/addgift/model/gift_request.freezed.dart
@@ -223,8 +223,8 @@ return $default(_that.user,_that.subTitle,_that.bgm,_that.password,_that.senderN
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _GiftRequest implements GiftRequest {
   const _GiftRequest({this.user = '', @JsonKey(name: 'sub_title') this.subTitle = '', this.bgm = '', this.password = '', @JsonKey(name: 'sender_name') this.senderName = '', final  List<GalleryItem> gallery = const <GalleryItem>[], @JsonKey(name: 'uploaded_bgm_urls') final  List<String> uploadedBgmUrls = const <String>[], @JsonKey(name: 'expired_at', includeIfNull: false) this.expiredAt, required this.content}): _gallery = gallery,_uploadedBgmUrls = uploadedBgmUrls;
   factory _GiftRequest.fromJson(Map<String, dynamic> json) => _$GiftRequestFromJson(json);

--- a/lib/features/addgift/model/gift_request.g.dart
+++ b/lib/features/addgift/model/gift_request.g.dart
@@ -33,8 +33,8 @@ Map<String, dynamic> _$GiftRequestToJson(_GiftRequest instance) =>
       'bgm': instance.bgm,
       'password': instance.password,
       'sender_name': instance.senderName,
-      'gallery': instance.gallery,
+      'gallery': instance.gallery.map((e) => e.toJson()).toList(),
       'uploaded_bgm_urls': instance.uploadedBgmUrls,
       'expired_at': ?instance.expiredAt,
-      'content': instance.content,
+      'content': instance.content.toJson(),
     };

--- a/lib/features/addgift/model/gift_request.g.dart
+++ b/lib/features/addgift/model/gift_request.g.dart
@@ -10,11 +10,19 @@ _GiftRequest _$GiftRequestFromJson(Map<String, dynamic> json) => _GiftRequest(
   user: json['user'] as String? ?? '',
   subTitle: json['sub_title'] as String? ?? '',
   bgm: json['bgm'] as String? ?? '',
+  password: json['password'] as String? ?? '',
+  senderName: json['sender_name'] as String? ?? '',
   gallery:
       (json['gallery'] as List<dynamic>?)
           ?.map((e) => GalleryItem.fromJson(e as Map<String, dynamic>))
           .toList() ??
       const <GalleryItem>[],
+  uploadedBgmUrls:
+      (json['uploaded_bgm_urls'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const <String>[],
+  expiredAt: json['expired_at'] as String?,
   content: GiftContent.fromJson(json['content'] as Map<String, dynamic>),
 );
 
@@ -23,6 +31,10 @@ Map<String, dynamic> _$GiftRequestToJson(_GiftRequest instance) =>
       'user': instance.user,
       'sub_title': instance.subTitle,
       'bgm': instance.bgm,
+      'password': instance.password,
+      'sender_name': instance.senderName,
       'gallery': instance.gallery,
+      'uploaded_bgm_urls': instance.uploadedBgmUrls,
+      'expired_at': ?instance.expiredAt,
       'content': instance.content,
     };

--- a/lib/features/addgift/model/quiz_content.dart
+++ b/lib/features/addgift/model/quiz_content.dart
@@ -7,6 +7,8 @@ part 'quiz_content.g.dart';
 
 @freezed
 abstract class QuizContent with _$QuizContent {
+  // ignore: invalid_annotation_target
+  @JsonSerializable(explicitToJson: true)
   const factory QuizContent({
     @JsonKey(name: 'success_reward') required QuizSuccessReward successReward,
     @JsonKey(name: 'fail_reward') required QuizFailReward failReward,

--- a/lib/features/addgift/model/quiz_content.freezed.dart
+++ b/lib/features/addgift/model/quiz_content.freezed.dart
@@ -226,8 +226,8 @@ return $default(_that.successReward,_that.failReward,_that.list);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _QuizContent implements QuizContent {
   const _QuizContent({@JsonKey(name: 'success_reward') required this.successReward, @JsonKey(name: 'fail_reward') required this.failReward, final  List<QuizItemModel> list = const <QuizItemModel>[]}): _list = list;
   factory _QuizContent.fromJson(Map<String, dynamic> json) => _$QuizContentFromJson(json);

--- a/lib/features/addgift/model/quiz_content.g.dart
+++ b/lib/features/addgift/model/quiz_content.g.dart
@@ -22,9 +22,9 @@ _QuizContent _$QuizContentFromJson(Map<String, dynamic> json) => _QuizContent(
 
 Map<String, dynamic> _$QuizContentToJson(_QuizContent instance) =>
     <String, dynamic>{
-      'success_reward': instance.successReward,
-      'fail_reward': instance.failReward,
-      'list': instance.list,
+      'success_reward': instance.successReward.toJson(),
+      'fail_reward': instance.failReward.toJson(),
+      'list': instance.list.map((e) => e.toJson()).toList(),
     };
 
 _QuizSuccessReward _$QuizSuccessRewardFromJson(Map<String, dynamic> json) =>

--- a/lib/features/addgift/model/unboxing_content.dart
+++ b/lib/features/addgift/model/unboxing_content.dart
@@ -7,6 +7,8 @@ part 'unboxing_content.g.dart';
 
 @freezed
 abstract class UnboxingContent with _$UnboxingContent {
+  // ignore: invalid_annotation_target
+  @JsonSerializable(explicitToJson: true)
   const factory UnboxingContent({
     @JsonKey(name: 'before_open') required BeforeOpen beforeOpen,
     @JsonKey(name: 'after_open') required AfterOpen afterOpen,

--- a/lib/features/addgift/model/unboxing_content.freezed.dart
+++ b/lib/features/addgift/model/unboxing_content.freezed.dart
@@ -225,8 +225,8 @@ return $default(_that.beforeOpen,_that.afterOpen);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(explicitToJson: true)
 class _UnboxingContent implements UnboxingContent {
   const _UnboxingContent({@JsonKey(name: 'before_open') required this.beforeOpen, @JsonKey(name: 'after_open') required this.afterOpen});
   factory _UnboxingContent.fromJson(Map<String, dynamic> json) => _$UnboxingContentFromJson(json);

--- a/lib/features/addgift/model/unboxing_content.g.dart
+++ b/lib/features/addgift/model/unboxing_content.g.dart
@@ -16,8 +16,8 @@ _UnboxingContent _$UnboxingContentFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$UnboxingContentToJson(_UnboxingContent instance) =>
     <String, dynamic>{
-      'before_open': instance.beforeOpen,
-      'after_open': instance.afterOpen,
+      'before_open': instance.beforeOpen.toJson(),
+      'after_open': instance.afterOpen.toJson(),
     };
 
 _BeforeOpen _$BeforeOpenFromJson(Map<String, dynamic> json) => _BeforeOpen(

--- a/lib/features/addgift/presentation/views/direct_open_setting_view.dart
+++ b/lib/features/addgift/presentation/views/direct_open_setting_view.dart
@@ -6,41 +6,56 @@ import 'package:image_picker/image_picker.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
+import '../../application/direct_open_setting/direct_open_setting_bloc.dart';
 import '../../application/gift_packaging_bloc.dart';
-import '../../model/direct_open_setting_models.dart';
-import '../../model/gift_content.dart';
-import '../../model/unboxing_content.dart';
 
-class DirectOpenSettingView extends StatefulWidget {
+class DirectOpenSettingView extends StatelessWidget {
   const DirectOpenSettingView({super.key});
 
   @override
-  State<DirectOpenSettingView> createState() => _DirectOpenSettingViewState();
+  Widget build(BuildContext context) {
+    return BlocProvider<DirectOpenSettingBloc>(
+      create: (BuildContext ctx) =>
+          DirectOpenSettingBloc(ctx.read<GiftPackagingBloc>()),
+      child: const _DirectOpenSettingContent(),
+    );
+  }
 }
 
-class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
+class _DirectOpenSettingContent extends StatefulWidget {
+  const _DirectOpenSettingContent();
+
+  @override
+  State<_DirectOpenSettingContent> createState() =>
+      _DirectOpenSettingContentState();
+}
+
+class _DirectOpenSettingContentState
+    extends State<_DirectOpenSettingContent> {
   final TextEditingController _userNameController = TextEditingController();
   final TextEditingController _subTitleController = TextEditingController();
-
-  final DirectOpenBeforeData _beforeData = DirectOpenBeforeData();
-  final DirectOpenAfterData _afterData = DirectOpenAfterData();
-
   final TextEditingController _beforeDescController = TextEditingController();
   final TextEditingController _afterNameController = TextEditingController();
 
-  String _selectedBgm = '신나는 생일';
+  final ImagePicker _picker = ImagePicker();
 
   @override
   void initState() {
     super.initState();
-    final GiftPackagingState blocState = context.read<GiftPackagingBloc>().state;
-    if (blocState.receiverName.isNotEmpty) {
-      _userNameController.text = blocState.receiverName;
+    final GiftPackagingState packagingState =
+        context.read<GiftPackagingBloc>().state;
+    if (packagingState.receiverName.isNotEmpty) {
+      _userNameController.text = packagingState.receiverName;
     }
-    // 초기 생성된 랜덤 타이틀을 서브타이틀 필드에 세팅
-    if (blocState.subTitle.isNotEmpty) {
-      _subTitleController.text = blocState.subTitle;
+    if (packagingState.subTitle.isNotEmpty) {
+      _subTitleController.text = packagingState.subTitle;
     }
+
+    // BLoC 초기 상태에서 설명 필드 초기화
+    final DirectOpenSettingState directOpenState =
+        context.read<DirectOpenSettingBloc>().state;
+    _beforeDescController.text = directOpenState.beforeDescription;
+    _afterNameController.text = directOpenState.afterItemName;
 
     _userNameController.addListener(() {
       context.read<GiftPackagingBloc>().add(
@@ -52,19 +67,15 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
         SetSubTitle(_subTitleController.text),
       );
     });
-
-    _beforeDescController.text = _beforeData.description;
-    _afterNameController.text = _afterData.itemName;
-
     _beforeDescController.addListener(() {
-      setState(() {
-        _beforeData.description = _beforeDescController.text;
-      });
+      context.read<DirectOpenSettingBloc>().add(
+        UpdateBeforeDescription(_beforeDescController.text),
+      );
     });
     _afterNameController.addListener(() {
-      setState(() {
-        _afterData.itemName = _afterNameController.text;
-      });
+      context.read<DirectOpenSettingBloc>().add(
+        UpdateAfterItemName(_afterNameController.text),
+      );
     });
   }
 
@@ -78,127 +89,144 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
   }
 
   Future<void> _pickImage(bool isBefore) async {
-    final ImagePicker picker = ImagePicker();
-    final XFile? image = await picker.pickImage(source: ImageSource.gallery);
-    if (image != null) {
-      setState(() {
-        if (isBefore) {
-          _beforeData.imageFile = image;
-        } else {
-          _afterData.imageFile = image;
-        }
-      });
+    final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
+    if (!mounted || image == null) return;
+    if (isBefore) {
+      context.read<DirectOpenSettingBloc>().add(UpdateBeforeImage(image));
+    } else {
+      context.read<DirectOpenSettingBloc>().add(UpdateAfterImage(image));
     }
   }
 
   void _completePackage() {
-    final GiftPackagingBloc bloc = context.read<GiftPackagingBloc>();
-    final GiftPackagingState packagingState = bloc.state;
-
-    // 로컬 데이터 -> freezed UnboxingContent 변환
-    final UnboxingContent unboxing = UnboxingContent(
-      beforeOpen: BeforeOpen(
-        imageUrl: _beforeData.imageFile?.path ?? '',
-        description: _beforeData.description,
-      ),
-      afterOpen: AfterOpen(
-        itemName: _afterData.itemName,
-        imageUrl: _afterData.imageFile?.path ?? '',
-      ),
-    );
-
-    // 모든 데이터를 SubmitPackage 이벤트에 직접 담아 전달
-    bloc.add(
-      SubmitPackage(
+    final GiftPackagingBloc packagingBloc = context.read<GiftPackagingBloc>();
+    context.read<DirectOpenSettingBloc>().add(
+      SubmitDirectOpenSetting(
         receiverName: _userNameController.text.trim(),
         subTitle: _subTitleController.text.trim(),
-        bgm: _selectedBgm,
-        gallery: packagingState.gallery,
-        content: GiftContent(unboxing: unboxing),
+        gallery: packagingBloc.state.gallery,
       ),
     );
-
-    isPackageComplete = true;
-    context.replace('/addgift/package-complete');
   }
 
   @override
   Widget build(BuildContext context) {
     final bool isMobile = MediaQuery.sizeOf(context).width < 800;
 
-    return Scaffold(
-      backgroundColor: AppColors.darkBg,
-      appBar: AppBar(
-        toolbarHeight: 68,
-        backgroundColor: AppColors.darkBg,
-        surfaceTintColor: Colors.transparent,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.white),
-        title: isMobile ? null : _buildTitleBar(),
-        actions: <Widget>[_buildStepIndicator()],
-      ),
-      body: Stack(
-        children: <Widget>[
-          Positioned.fill(child: CustomPaint(painter: GridBackgroundPainter())),
-          SafeArea(
-            child: isMobile
-                ? Column(
-                    children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.all(24.0),
-                        child: SingleChildScrollView(
-                          scrollDirection: Axis.horizontal,
-                          child: _buildTitleBar(),
-                        ),
-                      ),
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                          child: _buildContentSection(),
-                        ),
-                      ),
-                    ],
-                  )
-                : Row(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      Expanded(
-                        flex: 7,
-                        child: Padding(
-                          padding: const EdgeInsets.all(40.0),
-                          child: Center(
-                            child: ConstrainedBox(
-                              constraints: const BoxConstraints(maxWidth: 1000),
-                              child: _buildContentSection(),
+    return BlocListener<GiftPackagingBloc, GiftPackagingState>(
+      listenWhen: (GiftPackagingState prev, GiftPackagingState curr) =>
+          prev.submitStatus != curr.submitStatus,
+      listener: (BuildContext context, GiftPackagingState packagingState) {
+        if (packagingState.submitStatus == SubmitStatus.success) {
+          isPackageComplete = true;
+          context.replace('/addgift/package-complete');
+        } else if (packagingState.submitStatus == SubmitStatus.failure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('서버 전송에 실패했습니다. 다시 시도해 주세요.'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      },
+      child: BlocBuilder<DirectOpenSettingBloc, DirectOpenSettingState>(
+        builder: (BuildContext context, DirectOpenSettingState directOpenState) {
+          return Scaffold(
+            backgroundColor: AppColors.darkBg,
+            appBar: AppBar(
+              toolbarHeight: 68,
+              backgroundColor: AppColors.darkBg,
+              surfaceTintColor: Colors.transparent,
+              elevation: 0,
+              iconTheme: const IconThemeData(color: Colors.white),
+              title: isMobile ? null : _buildTitleBar(),
+              actions: <Widget>[_buildStepIndicator()],
+            ),
+            body: Stack(
+              children: <Widget>[
+                Positioned.fill(
+                  child: CustomPaint(painter: GridBackgroundPainter()),
+                ),
+                SafeArea(
+                  child: isMobile
+                      ? Column(
+                          children: <Widget>[
+                            Padding(
+                              padding: const EdgeInsets.all(24.0),
+                              child: SingleChildScrollView(
+                                scrollDirection: Axis.horizontal,
+                                child: _buildTitleBar(),
+                              ),
                             ),
-                          ),
-                        ),
-                      ),
-                      Container(width: 1, color: Colors.white.withValues(alpha: 0.1)),
-                      Expanded(
-                        flex: 3,
-                        child: Padding(
-                          padding: const EdgeInsets.all(40.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: <Widget>[
-                              Expanded(
-                                child: SingleChildScrollView(
-                                  child: _buildSettingsSection(isMobile: false),
+                            Expanded(
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 24.0,
+                                ),
+                                child: _buildContentSection(
+                                  isMobile,
+                                  directOpenState,
                                 ),
                               ),
-                              const SizedBox(height: 24),
-                              _buildCompleteButton(),
-                            ],
-                          ),
+                            ),
+                          ],
+                        )
+                      : Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: <Widget>[
+                            Expanded(
+                              flex: 7,
+                              child: Padding(
+                                padding: const EdgeInsets.all(40.0),
+                                child: Center(
+                                  child: ConstrainedBox(
+                                    constraints: const BoxConstraints(
+                                      maxWidth: 1000,
+                                    ),
+                                    child: _buildContentSection(
+                                      isMobile,
+                                      directOpenState,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            Container(
+                              width: 1,
+                              color: Colors.white.withValues(alpha: 0.1),
+                            ),
+                            Expanded(
+                              flex: 3,
+                              child: Padding(
+                                padding: const EdgeInsets.all(40.0),
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: <Widget>[
+                                    Expanded(
+                                      child: SingleChildScrollView(
+                                        child: _buildSettingsSection(
+                                          directOpenState,
+                                          isMobile: false,
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 24),
+                                    _buildCompleteButton(),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
-                      ),
-                    ],
-                  ),
-          ),
-        ],
+                ),
+              ],
+            ),
+            bottomNavigationBar:
+                isMobile ? _buildMobileBottomBar(directOpenState) : null,
+          );
+        },
       ),
-      bottomNavigationBar: isMobile ? _buildMobileBottomBar() : null,
     );
   }
 
@@ -224,7 +252,9 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
       height: 28,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: isActive ? AppColors.pixelPurple : Colors.white.withValues(alpha: 0.1),
+        color: isActive
+            ? AppColors.pixelPurple
+            : Colors.white.withValues(alpha: 0.1),
         border: isActive ? null : Border.all(color: Colors.white24),
       ),
       child: Center(
@@ -244,7 +274,9 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
     return Container(
       width: 16,
       height: 2,
-      color: isActive ? AppColors.pixelPurple.withValues(alpha: 0.5) : Colors.white12,
+      color: isActive
+          ? AppColors.pixelPurple.withValues(alpha: 0.5)
+          : Colors.white12,
     );
   }
 
@@ -268,21 +300,33 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
               ),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.3), width: 1),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(color: AppColors.pixelPurple, width: 1.5),
+                borderSide: const BorderSide(
+                  color: AppColors.pixelPurple,
+                  width: 1.5,
+                ),
               ),
             ),
           ),
         ),
         const SizedBox(width: 8),
-        const Text('님의', style: TextStyle(fontSize: 16, color: Colors.white70)),
+        const Text(
+          '님의',
+          style: TextStyle(fontSize: 16, color: Colors.white70),
+        ),
         const SizedBox(width: 8),
         SizedBox(
           width: 120,
@@ -299,43 +343,60 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
               ),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.3), width: 1),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(color: AppColors.pixelPurple, width: 1.5),
+                borderSide: const BorderSide(
+                  color: AppColors.pixelPurple,
+                  width: 1.5,
+                ),
               ),
             ),
           ),
         ),
         const SizedBox(width: 8),
-        const Text('선물 개봉', style: TextStyle(fontSize: 16, color: Colors.white70)),
+        const Text(
+          '선물 개봉',
+          style: TextStyle(fontSize: 16, color: Colors.white70),
+        ),
       ],
     );
   }
 
-  Widget _buildContentSection() {
-    final bool isMobile = MediaQuery.sizeOf(context).width < 800;
-
+  Widget _buildContentSection(
+    bool isMobile,
+    DirectOpenSettingState state,
+  ) {
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           if (isMobile) ...<Widget>[
-            _buildBeforeOpenCard(isMobile: isMobile),
+            _buildBeforeOpenCard(isMobile: isMobile, state: state),
             const SizedBox(height: 24),
-            _buildAfterOpenCard(isMobile: isMobile),
+            _buildAfterOpenCard(isMobile: isMobile, state: state),
           ] else ...<Widget>[
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Expanded(child: _buildBeforeOpenCard(isMobile: isMobile)),
+                Expanded(
+                  child: _buildBeforeOpenCard(isMobile: isMobile, state: state),
+                ),
                 const SizedBox(width: 32),
-                Expanded(child: _buildAfterOpenCard(isMobile: isMobile)),
+                Expanded(
+                  child: _buildAfterOpenCard(isMobile: isMobile, state: state),
+                ),
               ],
             ),
           ],
@@ -344,7 +405,10 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
     );
   }
 
-  Widget _buildBeforeOpenCard({bool isMobile = true}) {
+  Widget _buildBeforeOpenCard({
+    bool isMobile = true,
+    required DirectOpenSettingState state,
+  }) {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
@@ -357,7 +421,11 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
         children: <Widget>[
           const Text(
             '개봉 전',
-            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white),
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
           ),
           const SizedBox(height: 16),
           InkWell(
@@ -369,15 +437,18 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
               decoration: BoxDecoration(
                 color: Colors.white12,
                 borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: Colors.white.withValues(alpha: 0.2), width: 2),
-                image: _beforeData.imageFile != null
+                border: Border.all(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 2,
+                ),
+                image: state.beforeImageFile != null
                     ? DecorationImage(
-                        image: NetworkImage(_beforeData.imageFile!.path),
+                        image: NetworkImage(state.beforeImageFile!.path),
                         fit: BoxFit.cover,
                       )
                     : null,
               ),
-              child: _beforeData.imageFile == null
+              child: state.beforeImageFile == null
                   ? const Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
@@ -404,7 +475,10 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
             alignment: Alignment.centerLeft,
             child: Text(
               '설명란 문구',
-              style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
             ),
           ),
           const SizedBox(height: 8),
@@ -418,11 +492,15 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
               fillColor: Colors.white12,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
@@ -435,7 +513,10 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
     );
   }
 
-  Widget _buildAfterOpenCard({bool isMobile = true}) {
+  Widget _buildAfterOpenCard({
+    bool isMobile = true,
+    required DirectOpenSettingState state,
+  }) {
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
@@ -448,7 +529,11 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
         children: <Widget>[
           const Text(
             '개봉 후',
-            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white),
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
           ),
           const SizedBox(height: 16),
           InkWell(
@@ -460,15 +545,18 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
               decoration: BoxDecoration(
                 color: Colors.white12,
                 borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: Colors.white.withValues(alpha: 0.2), width: 2),
-                image: _afterData.imageFile != null
+                border: Border.all(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 2,
+                ),
+                image: state.afterImageFile != null
                     ? DecorationImage(
-                        image: NetworkImage(_afterData.imageFile!.path),
+                        image: NetworkImage(state.afterImageFile!.path),
                         fit: BoxFit.cover,
                       )
                     : null,
               ),
-              child: _afterData.imageFile == null
+              child: state.afterImageFile == null
                   ? const Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
@@ -493,7 +581,13 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
           const SizedBox(height: 24),
           const Align(
             alignment: Alignment.centerLeft,
-            child: Text('물품 이름', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white)),
+            child: Text(
+              '물품 이름',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
           ),
           const SizedBox(height: 8),
           TextField(
@@ -506,11 +600,15 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
               fillColor: Colors.white12,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
@@ -523,13 +621,20 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
     );
   }
 
-  Widget _buildSettingsSection({required bool isMobile}) {
+  Widget _buildSettingsSection(
+    DirectOpenSettingState state, {
+    required bool isMobile,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         const Text(
           'BGM (배경음악)',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
         ),
         const SizedBox(height: 8),
         Row(
@@ -543,21 +648,26 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
                 ),
                 child: DropdownButtonHideUnderline(
                   child: DropdownButton<String>(
-                    value: _selectedBgm,
+                    value: state.selectedBgm,
                     isExpanded: true,
                     dropdownColor: const Color(0xFF1A1A1A),
                     style: const TextStyle(color: Colors.white),
                     iconEnabledColor: Colors.white38,
                     onChanged: (String? val) {
-                      setState(() {
-                        _selectedBgm = val!;
-                      });
+                      if (val != null) {
+                        context.read<DirectOpenSettingBloc>().add(
+                          UpdateDirectOpenBgm(val),
+                        );
+                      }
                     },
                     items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
                         .map(
                           (String value) => DropdownMenuItem<String>(
                             value: value,
-                            child: Text(value, overflow: TextOverflow.ellipsis),
+                            child: Text(
+                              value,
+                              overflow: TextOverflow.ellipsis,
+                            ),
                           ),
                         )
                         .toList(),
@@ -605,7 +715,7 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
     );
   }
 
-  Widget _buildMobileBottomBar() {
+  Widget _buildMobileBottomBar(DirectOpenSettingState state) {
     return SafeArea(
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
@@ -616,9 +726,7 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
         child: Row(
           children: <Widget>[
             InkWell(
-              onTap: () {
-                _showMobileSettingsModal(context);
-              },
+              onTap: () => _showMobileSettingsModal(state),
               borderRadius: BorderRadius.circular(16),
               child: Container(
                 width: 56,
@@ -626,7 +734,10 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
                 decoration: BoxDecoration(
                   color: Colors.white.withValues(alpha: 0.07),
                   borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: Colors.white.withValues(alpha: 0.15), width: 2),
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    width: 2,
+                  ),
                 ),
                 child: const Icon(Icons.settings, color: Colors.white60),
               ),
@@ -639,79 +750,81 @@ class _DirectOpenSettingViewState extends State<DirectOpenSettingView> {
     );
   }
 
-  void _showMobileSettingsModal(BuildContext context) {
+  void _showMobileSettingsModal(DirectOpenSettingState currentState) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (BuildContext context) {
-        return StatefulBuilder(
-          builder: (BuildContext context, StateSetter modalSetState) {
-            return SafeArea(
-              child: Container(
-                padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom,
-                ),
-                decoration: const BoxDecoration(
-                  color: AppColors.darkBg,
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-                ),
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.all(24.0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      Container(
-                        width: 40,
-                        height: 4,
-                        margin: const EdgeInsets.only(bottom: 24),
-                        decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.15),
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                      const Text(
-                        '세팅',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-                      _buildSettingsSection(isMobile: true),
-                      const SizedBox(height: 16),
-                      SizedBox(
-                        width: double.infinity,
-                        child: ElevatedButton(
-                          onPressed: () {
-                            Navigator.pop(context);
-                            setState(() {});
-                          },
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: AppColors.pixelPurple,
-                            foregroundColor: Colors.white,
-                            padding: const EdgeInsets.symmetric(vertical: 16),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            elevation: 0,
-                          ),
-                          child: const Text(
-                            '닫기',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                            ),
+      builder: (BuildContext modalContext) {
+        return BlocProvider<DirectOpenSettingBloc>.value(
+          value: context.read<DirectOpenSettingBloc>(),
+          child: BlocBuilder<DirectOpenSettingBloc, DirectOpenSettingState>(
+            builder: (BuildContext innerCtx, DirectOpenSettingState state) {
+              return SafeArea(
+                child: Container(
+                  padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(innerCtx).viewInsets.bottom,
+                  ),
+                  decoration: const BoxDecoration(
+                    color: AppColors.darkBg,
+                    borderRadius: BorderRadius.vertical(
+                      top: Radius.circular(24),
+                    ),
+                  ),
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(24.0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Container(
+                          width: 40,
+                          height: 4,
+                          margin: const EdgeInsets.only(bottom: 24),
+                          decoration: BoxDecoration(
+                            color: Colors.white.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(2),
                           ),
                         ),
-                      ),
-                    ],
+                        const Text(
+                          '세팅',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        _buildSettingsSection(state, isMobile: true),
+                        const SizedBox(height: 16),
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            onPressed: () => Navigator.pop(innerCtx),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.pixelPurple,
+                              foregroundColor: Colors.white,
+                              padding: const EdgeInsets.symmetric(vertical: 16),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              elevation: 0,
+                            ),
+                            child: const Text(
+                              '닫기',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         );
       },
     );

--- a/lib/features/addgift/presentation/views/direct_open_setting_view.dart
+++ b/lib/features/addgift/presentation/views/direct_open_setting_view.dart
@@ -8,6 +8,8 @@ import '../../../../core/router/app_router.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
 import '../../application/direct_open_setting/direct_open_setting_bloc.dart';
 import '../../application/gift_packaging_bloc.dart';
+import '../widgets/direct_open/after_open_card.dart';
+import '../widgets/direct_open/before_open_card.dart';
 
 class DirectOpenSettingView extends StatelessWidget {
   const DirectOpenSettingView({super.key});
@@ -383,9 +385,19 @@ class _DirectOpenSettingContentState
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           if (isMobile) ...<Widget>[
-            _buildBeforeOpenCard(isMobile: isMobile, state: state),
+            BeforeOpenCard(
+                isMobile: isMobile,
+                imageFile: state.beforeImageFile,
+                descController: _beforeDescController,
+                onPickImage: () => _pickImage(true),
+              ),
             const SizedBox(height: 24),
-            _buildAfterOpenCard(isMobile: isMobile, state: state),
+            AfterOpenCard(
+                isMobile: isMobile,
+                imageFile: state.afterImageFile,
+                nameController: _afterNameController,
+                onPickImage: () => _pickImage(false),
+              ),
           ] else ...<Widget>[
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/addgift/presentation/views/direct_open_setting_view.dart
+++ b/lib/features/addgift/presentation/views/direct_open_setting_view.dart
@@ -403,231 +403,25 @@ class _DirectOpenSettingContentState
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Expanded(
-                  child: _buildBeforeOpenCard(isMobile: isMobile, state: state),
+                  child: BeforeOpenCard(
+                    isMobile: isMobile,
+                    imageFile: state.beforeImageFile,
+                    descController: _beforeDescController,
+                    onPickImage: () => _pickImage(true),
+                  ),
                 ),
                 const SizedBox(width: 32),
                 Expanded(
-                  child: _buildAfterOpenCard(isMobile: isMobile, state: state),
+                  child: AfterOpenCard(
+                    isMobile: isMobile,
+                    imageFile: state.afterImageFile,
+                    nameController: _afterNameController,
+                    onPickImage: () => _pickImage(false),
+                  ),
                 ),
               ],
             ),
           ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildBeforeOpenCard({
-    bool isMobile = true,
-    required DirectOpenSettingState state,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
-          const Text(
-            '개봉 전',
-            style: TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
-            ),
-          ),
-          const SizedBox(height: 16),
-          InkWell(
-            onTap: () => _pickImage(true),
-            borderRadius: BorderRadius.circular(16),
-            child: Container(
-              width: isMobile ? 200 : 280,
-              height: isMobile ? 200 : 280,
-              decoration: BoxDecoration(
-                color: Colors.white12,
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.2),
-                  width: 2,
-                ),
-                image: state.beforeImageFile != null
-                    ? DecorationImage(
-                        image: NetworkImage(state.beforeImageFile!.path),
-                        fit: BoxFit.cover,
-                      )
-                    : null,
-              ),
-              child: state.beforeImageFile == null
-                  ? const Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        Icon(
-                          Icons.card_giftcard,
-                          size: 64,
-                          color: Colors.white38,
-                        ),
-                        SizedBox(height: 8),
-                        Text(
-                          '상자 이미지 변경',
-                          style: TextStyle(
-                            color: Colors.white38,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
-                    )
-                  : null,
-            ),
-          ),
-          const SizedBox(height: 24),
-          const Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              '설명란 문구',
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-              ),
-            ),
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: _beforeDescController,
-            style: const TextStyle(color: Colors.white),
-            decoration: InputDecoration(
-              hintText: '상자 하단에 보여질 설명을 입력해주세요.',
-              hintStyle: const TextStyle(color: Colors.white38),
-              filled: true,
-              fillColor: Colors.white12,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.15),
-                ),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.15),
-                ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(color: AppColors.pixelPurple),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAfterOpenCard({
-    bool isMobile = true,
-    required DirectOpenSettingState state,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
-          const Text(
-            '개봉 후',
-            style: TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
-            ),
-          ),
-          const SizedBox(height: 16),
-          InkWell(
-            onTap: () => _pickImage(false),
-            borderRadius: BorderRadius.circular(16),
-            child: Container(
-              width: isMobile ? 200 : 280,
-              height: isMobile ? 200 : 280,
-              decoration: BoxDecoration(
-                color: Colors.white12,
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.2),
-                  width: 2,
-                ),
-                image: state.afterImageFile != null
-                    ? DecorationImage(
-                        image: NetworkImage(state.afterImageFile!.path),
-                        fit: BoxFit.cover,
-                      )
-                    : null,
-              ),
-              child: state.afterImageFile == null
-                  ? const Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        Icon(
-                          Icons.image,
-                          size: 64,
-                          color: Colors.white38,
-                        ),
-                        SizedBox(height: 8),
-                        Text(
-                          '물품 사진 등록',
-                          style: TextStyle(
-                            color: Colors.white38,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
-                    )
-                  : null,
-            ),
-          ),
-          const SizedBox(height: 24),
-          const Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              '물품 이름',
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-              ),
-            ),
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: _afterNameController,
-            style: const TextStyle(color: Colors.white),
-            decoration: InputDecoration(
-              hintText: '상품 이름을 기입해주세요.',
-              hintStyle: const TextStyle(color: Colors.white38),
-              filled: true,
-              fillColor: Colors.white12,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.15),
-                ),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.15),
-                ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(color: AppColors.pixelPurple),
-              ),
-            ),
-          ),
         ],
       ),
     );

--- a/lib/features/addgift/presentation/views/direct_open_setting_view.dart
+++ b/lib/features/addgift/presentation/views/direct_open_setting_view.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
+import '../../../../core/widgets/packaging_loading_overlay.dart';
 import '../../application/direct_open_setting/direct_open_setting_bloc.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../widgets/direct_open/after_open_card.dart';
@@ -40,6 +41,8 @@ class _DirectOpenSettingContentState
   final TextEditingController _afterNameController = TextEditingController();
 
   final ImagePicker _picker = ImagePicker();
+
+  bool _isSubmitting = false;
 
   @override
   void initState() {
@@ -123,17 +126,22 @@ class _DirectOpenSettingContentState
           isPackageComplete = true;
           context.replace('/addgift/package-complete');
         } else if (packagingState.submitStatus == SubmitStatus.failure) {
+          setState(() => _isSubmitting = false);
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
               content: Text('서버 전송에 실패했습니다. 다시 시도해 주세요.'),
               backgroundColor: Colors.red,
             ),
           );
+        } else if (packagingState.submitStatus == SubmitStatus.loading) {
+          setState(() => _isSubmitting = true);
         }
       },
       child: BlocBuilder<DirectOpenSettingBloc, DirectOpenSettingState>(
         builder: (BuildContext context, DirectOpenSettingState directOpenState) {
-          return Scaffold(
+          return PopScope(
+            canPop: !_isSubmitting,
+            child: Scaffold(
             backgroundColor: AppColors.darkBg,
             appBar: AppBar(
               toolbarHeight: 68,
@@ -222,10 +230,13 @@ class _DirectOpenSettingContentState
                           ],
                         ),
                 ),
+                // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
+                if (_isSubmitting) const PackagingLoadingOverlay(),
               ],
             ),
             bottomNavigationBar:
                 isMobile ? _buildMobileBottomBar(directOpenState) : null,
+          ),
           );
         },
       ),

--- a/lib/features/addgift/presentation/views/direct_open_setting_view.dart
+++ b/lib/features/addgift/presentation/views/direct_open_setting_view.dart
@@ -9,8 +9,12 @@ import '../../../../core/widgets/grid_background_painter.dart';
 import '../../../../core/widgets/packaging_loading_overlay.dart';
 import '../../application/direct_open_setting/direct_open_setting_bloc.dart';
 import '../../application/gift_packaging_bloc.dart';
-import '../widgets/direct_open/after_open_card.dart';
-import '../widgets/direct_open/before_open_card.dart';
+import '../widgets/direct_open/direct_open_complete_button.dart';
+import '../widgets/direct_open/direct_open_content_section.dart';
+import '../widgets/direct_open/direct_open_mobile_bottom_bar.dart';
+import '../widgets/direct_open/direct_open_settings_section.dart';
+import '../widgets/direct_open/direct_open_step_indicator.dart';
+import '../widgets/direct_open/direct_open_title_bar.dart';
 
 class DirectOpenSettingView extends StatelessWidget {
   const DirectOpenSettingView({super.key});
@@ -33,8 +37,7 @@ class _DirectOpenSettingContent extends StatefulWidget {
       _DirectOpenSettingContentState();
 }
 
-class _DirectOpenSettingContentState
-    extends State<_DirectOpenSettingContent> {
+class _DirectOpenSettingContentState extends State<_DirectOpenSettingContent> {
   final TextEditingController _userNameController = TextEditingController();
   final TextEditingController _subTitleController = TextEditingController();
   final TextEditingController _beforeDescController = TextEditingController();
@@ -47,8 +50,9 @@ class _DirectOpenSettingContentState
   @override
   void initState() {
     super.initState();
-    final GiftPackagingState packagingState =
-        context.read<GiftPackagingBloc>().state;
+    final GiftPackagingState packagingState = context
+        .read<GiftPackagingBloc>()
+        .state;
     if (packagingState.receiverName.isNotEmpty) {
       _userNameController.text = packagingState.receiverName;
     }
@@ -57,8 +61,9 @@ class _DirectOpenSettingContentState
     }
 
     // BLoC 초기 상태에서 설명 필드 초기화
-    final DirectOpenSettingState directOpenState =
-        context.read<DirectOpenSettingBloc>().state;
+    final DirectOpenSettingState directOpenState = context
+        .read<DirectOpenSettingBloc>()
+        .state;
     _beforeDescController.text = directOpenState.beforeDescription;
     _afterNameController.text = directOpenState.afterItemName;
 
@@ -138,436 +143,142 @@ class _DirectOpenSettingContentState
         }
       },
       child: BlocBuilder<DirectOpenSettingBloc, DirectOpenSettingState>(
-        builder: (BuildContext context, DirectOpenSettingState directOpenState) {
-          return PopScope(
-            canPop: !_isSubmitting,
-            child: Scaffold(
-            backgroundColor: AppColors.darkBg,
-            appBar: AppBar(
-              toolbarHeight: 68,
-              backgroundColor: AppColors.darkBg,
-              surfaceTintColor: Colors.transparent,
-              elevation: 0,
-              iconTheme: const IconThemeData(color: Colors.white),
-              title: isMobile ? null : _buildTitleBar(),
-              actions: <Widget>[_buildStepIndicator()],
-            ),
-            body: Stack(
-              children: <Widget>[
-                Positioned.fill(
-                  child: CustomPaint(painter: GridBackgroundPainter()),
-                ),
-                SafeArea(
-                  child: isMobile
-                      ? Column(
-                          children: <Widget>[
-                            Padding(
-                              padding: const EdgeInsets.all(24.0),
-                              child: SingleChildScrollView(
-                                scrollDirection: Axis.horizontal,
-                                child: _buildTitleBar(),
-                              ),
-                            ),
-                            Expanded(
-                              child: Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 24.0,
-                                ),
-                                child: _buildContentSection(
-                                  isMobile,
-                                  directOpenState,
-                                ),
-                              ),
-                            ),
-                          ],
-                        )
-                      : Row(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: <Widget>[
-                            Expanded(
-                              flex: 7,
-                              child: Padding(
-                                padding: const EdgeInsets.all(40.0),
-                                child: Center(
-                                  child: ConstrainedBox(
-                                    constraints: const BoxConstraints(
-                                      maxWidth: 1000,
-                                    ),
-                                    child: _buildContentSection(
-                                      isMobile,
-                                      directOpenState,
+        builder:
+            (BuildContext context, DirectOpenSettingState directOpenState) {
+              return PopScope(
+                canPop: !_isSubmitting,
+                child: Scaffold(
+                  backgroundColor: AppColors.darkBg,
+                  appBar: AppBar(
+                    toolbarHeight: 68,
+                    backgroundColor: AppColors.darkBg,
+                    surfaceTintColor: Colors.transparent,
+                    elevation: 0,
+                    iconTheme: const IconThemeData(color: Colors.white),
+                    title: isMobile
+                        ? null
+                        : DirectOpenTitleBar(
+                            userNameController: _userNameController,
+                            subTitleController: _subTitleController,
+                          ),
+                    actions: const <Widget>[DirectOpenStepIndicator()],
+                  ),
+                  body: Stack(
+                    children: <Widget>[
+                      Positioned.fill(
+                        child: CustomPaint(painter: GridBackgroundPainter()),
+                      ),
+                      SafeArea(
+                        child: isMobile
+                            ? Column(
+                                children: <Widget>[
+                                  Padding(
+                                    padding: const EdgeInsets.all(24.0),
+                                    child: SingleChildScrollView(
+                                      scrollDirection: Axis.horizontal,
+                                      child: DirectOpenTitleBar(
+                                        userNameController: _userNameController,
+                                        subTitleController: _subTitleController,
+                                      ),
                                     ),
                                   ),
-                                ),
-                              ),
-                            ),
-                            Container(
-                              width: 1,
-                              color: Colors.white.withValues(alpha: 0.1),
-                            ),
-                            Expanded(
-                              flex: 3,
-                              child: Padding(
-                                padding: const EdgeInsets.all(40.0),
-                                child: Column(
-                                  crossAxisAlignment:
-                                      CrossAxisAlignment.stretch,
-                                  children: <Widget>[
-                                    Expanded(
-                                      child: SingleChildScrollView(
-                                        child: _buildSettingsSection(
-                                          directOpenState,
-                                          isMobile: false,
+                                  Expanded(
+                                    child: Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 24.0,
+                                      ),
+                                      child: DirectOpenContentSection(
+                                        isMobile: isMobile,
+                                        state: directOpenState,
+                                        beforeDescController:
+                                            _beforeDescController,
+                                        afterNameController:
+                                            _afterNameController,
+                                        onPickBeforeImage: () =>
+                                            _pickImage(true),
+                                        onPickAfterImage: () =>
+                                            _pickImage(false),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              )
+                            : Row(
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: <Widget>[
+                                  Expanded(
+                                    flex: 7,
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(40.0),
+                                      child: Center(
+                                        child: ConstrainedBox(
+                                          constraints: const BoxConstraints(
+                                            maxWidth: 1000,
+                                          ),
+                                          child: DirectOpenContentSection(
+                                            isMobile: isMobile,
+                                            state: directOpenState,
+                                            beforeDescController:
+                                                _beforeDescController,
+                                            afterNameController:
+                                                _afterNameController,
+                                            onPickBeforeImage: () =>
+                                                _pickImage(true),
+                                            onPickAfterImage: () =>
+                                                _pickImage(false),
+                                          ),
                                         ),
                                       ),
                                     ),
-                                    const SizedBox(height: 24),
-                                    _buildCompleteButton(),
-                                  ],
-                                ),
+                                  ),
+                                  Container(
+                                    width: 1,
+                                    color: Colors.white.withValues(alpha: 0.1),
+                                  ),
+                                  Expanded(
+                                    flex: 3,
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(40.0),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.stretch,
+                                        children: <Widget>[
+                                          Expanded(
+                                            child: SingleChildScrollView(
+                                              child: DirectOpenSettingsSection(
+                                                state: directOpenState,
+                                              ),
+                                            ),
+                                          ),
+                                          const SizedBox(height: 24),
+                                          DirectOpenCompleteButton(
+                                            onPressed: _completePackage,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ],
                               ),
-                            ),
-                          ],
-                        ),
-                ),
-                // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
-                if (_isSubmitting) const PackagingLoadingOverlay(),
-              ],
-            ),
-            bottomNavigationBar:
-                isMobile ? _buildMobileBottomBar(directOpenState) : null,
-          ),
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _buildStepIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 20.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildCircle(isActive: true, number: '1'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '2'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '3'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCircle({required bool isActive, required String number}) {
-    return Container(
-      width: 28,
-      height: 28,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: isActive
-            ? AppColors.pixelPurple
-            : Colors.white.withValues(alpha: 0.1),
-        border: isActive ? null : Border.all(color: Colors.white24),
-      ),
-      child: Center(
-        child: Text(
-          number,
-          style: TextStyle(
-            color: isActive ? Colors.white : Colors.white38,
-            fontSize: 14,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLine({required bool isActive}) {
-    return Container(
-      width: 16,
-      height: 2,
-      color: isActive
-          ? AppColors.pixelPurple.withValues(alpha: 0.5)
-          : Colors.white12,
-    );
-  }
-
-  Widget _buildTitleBar() {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: <Widget>[
-        SizedBox(
-          width: 100,
-          child: TextFormField(
-            controller: _userNameController,
-            style: const TextStyle(color: Colors.white),
-            decoration: InputDecoration(
-              hintText: '닉네임',
-              hintStyle: const TextStyle(color: Colors.white38),
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                vertical: 8,
-                horizontal: 12,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.3),
-                  width: 1,
-                ),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.2),
-                  width: 1,
-                ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(
-                  color: AppColors.pixelPurple,
-                  width: 1.5,
-                ),
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        const Text(
-          '님의',
-          style: TextStyle(fontSize: 16, color: Colors.white70),
-        ),
-        const SizedBox(width: 8),
-        SizedBox(
-          width: 120,
-          child: TextFormField(
-            controller: _subTitleController,
-            style: const TextStyle(color: Colors.white),
-            decoration: InputDecoration(
-              hintText: '서브 타이틀',
-              hintStyle: const TextStyle(color: Colors.white38),
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                vertical: 8,
-                horizontal: 12,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.3),
-                  width: 1,
-                ),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.2),
-                  width: 1,
-                ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(
-                  color: AppColors.pixelPurple,
-                  width: 1.5,
-                ),
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        const Text(
-          '선물 개봉',
-          style: TextStyle(fontSize: 16, color: Colors.white70),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildContentSection(
-    bool isMobile,
-    DirectOpenSettingState state,
-  ) {
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          if (isMobile) ...<Widget>[
-            BeforeOpenCard(
-                isMobile: isMobile,
-                imageFile: state.beforeImageFile,
-                descController: _beforeDescController,
-                onPickImage: () => _pickImage(true),
-              ),
-            const SizedBox(height: 24),
-            AfterOpenCard(
-                isMobile: isMobile,
-                imageFile: state.afterImageFile,
-                nameController: _afterNameController,
-                onPickImage: () => _pickImage(false),
-              ),
-          ] else ...<Widget>[
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Expanded(
-                  child: BeforeOpenCard(
-                    isMobile: isMobile,
-                    imageFile: state.beforeImageFile,
-                    descController: _beforeDescController,
-                    onPickImage: () => _pickImage(true),
+                      ),
+                      // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
+                      if (_isSubmitting) const PackagingLoadingOverlay(),
+                    ],
                   ),
-                ),
-                const SizedBox(width: 32),
-                Expanded(
-                  child: AfterOpenCard(
-                    isMobile: isMobile,
-                    imageFile: state.afterImageFile,
-                    nameController: _afterNameController,
-                    onPickImage: () => _pickImage(false),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSettingsSection(
-    DirectOpenSettingState state, {
-    required bool isMobile,
-  }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        const Text(
-          'BGM (배경음악)',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-          ),
-        ),
-        const SizedBox(height: 8),
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                decoration: BoxDecoration(
-                  color: Colors.white12,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: DropdownButtonHideUnderline(
-                  child: DropdownButton<String>(
-                    value: state.selectedBgm,
-                    isExpanded: true,
-                    dropdownColor: const Color(0xFF1A1A1A),
-                    style: const TextStyle(color: Colors.white),
-                    iconEnabledColor: Colors.white38,
-                    onChanged: (String? val) {
-                      if (val != null) {
-                        context.read<DirectOpenSettingBloc>().add(
-                          UpdateDirectOpenBgm(val),
-                        );
-                      }
-                    },
-                    items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
-                        .map(
-                          (String value) => DropdownMenuItem<String>(
-                            value: value,
-                            child: Text(
-                              value,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
+                  bottomNavigationBar: isMobile
+                      ? DirectOpenMobileBottomBar(
+                          onShowSettings: _showMobileSettingsModal,
+                          onComplete: _completePackage,
                         )
-                        .toList(),
-                  ),
+                      : null,
                 ),
-              ),
-            ),
-            const SizedBox(width: 8),
-            Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: Colors.white12,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: const Icon(Icons.play_arrow, color: Colors.white38),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  Widget _buildCompleteButton() {
-    return SizedBox(
-      height: 60,
-      child: ElevatedButton(
-        onPressed: _completePackage,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF6DE1F1),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-          elevation: 0,
-        ),
-        child: const Text(
-          '포장 완료',
-          style: TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-            color: Colors.black,
-          ),
-        ),
+              );
+            },
       ),
     );
   }
 
-  Widget _buildMobileBottomBar(DirectOpenSettingState state) {
-    return SafeArea(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-        decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.07),
-          border: const Border(top: BorderSide(color: Colors.white12)),
-        ),
-        child: Row(
-          children: <Widget>[
-            InkWell(
-              onTap: () => _showMobileSettingsModal(state),
-              borderRadius: BorderRadius.circular(16),
-              child: Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.07),
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.15),
-                    width: 2,
-                  ),
-                ),
-                child: const Icon(Icons.settings, color: Colors.white60),
-              ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(child: _buildCompleteButton()),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showMobileSettingsModal(DirectOpenSettingState currentState) {
+  void _showMobileSettingsModal() {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -611,7 +322,7 @@ class _DirectOpenSettingContentState
                           ),
                         ),
                         const SizedBox(height: 24),
-                        _buildSettingsSection(state, isMobile: true),
+                        DirectOpenSettingsSection(state: state),
                         const SizedBox(height: 16),
                         SizedBox(
                           width: double.infinity,

--- a/lib/features/addgift/presentation/views/gacha_setting_view.dart
+++ b/lib/features/addgift/presentation/views/gacha_setting_view.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gifo/features/addgift/model/gacha_content.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/features/addgift/presentation/views/gacha_setting_view.dart
+++ b/lib/features/addgift/presentation/views/gacha_setting_view.dart
@@ -12,6 +12,10 @@ import '../../../../core/router/app_router.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
 import '../../application/gacha_setting/gacha_setting_bloc.dart';
 import '../../application/gift_packaging_bloc.dart';
+import '../widgets/gacha/gacha_capsule_item.dart';
+import '../widgets/gacha/gacha_mobile_bottom_bar.dart';
+import '../widgets/gacha/gacha_settings_panel.dart';
+import '../widgets/step_indicator.dart';
 
 class GachaSettingView extends StatelessWidget {
   const GachaSettingView({super.key});
@@ -848,7 +852,7 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                                 },
                         ),
                         title: _buildTitleBar(),
-                        actions: <Widget>[if (!isMobile) _buildStepIndicator()],
+                        actions: <Widget>[if (!isMobile) const StepIndicator(activeStep: 3)],
                       ),
                       body: Stack(
                         children: <Widget>[
@@ -899,8 +903,11 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                                     flex: 4,
                                     child: Padding(
                                       padding: const EdgeInsets.all(40.0),
-                                      child: _buildSettingsSection(
+                                      child: GachaSettingsPanel(
                                         isMobile: false,
+                                        playCountController: _playCountController,
+                                        canComplete: _canComplete(),
+                                        onComplete: _completePackage,
                                       ),
                                     ),
                                   ),
@@ -911,9 +918,13 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                       ),
                       // 모바일인 경우 하단 네비게이션 적용 (톱니바퀴 모달 + 완료버튼)
                       bottomNavigationBar: isMobile
-                          ? _buildMobileBottomBar(
-                              totalPercent,
-                              gachaState.uiItems.length,
+                          ? GachaMobileBottomBar(
+                              totalPercent: totalPercent,
+                              itemCount: gachaState.uiItems.length,
+                              canComplete: _canComplete(),
+                              onComplete: _completePackage,
+                              onShowSettings: () =>
+                                  _showMobileSettingsModal(context),
                             )
                           : null,
                     ),
@@ -1206,7 +1217,27 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
         runSpacing: 32,
         children: <Widget>[
           for (int i = 0; i < uiItems.length; i++)
-            _buildCapsuleItem(uiItems[i], isMobile),
+            GachaCapsuleItem(
+              item: uiItems[i],
+              isMobile: isMobile,
+              isHovered: _hoveredItemId == uiItems[i].id,
+              isSelected: _selectedItemId == uiItems[i].id,
+              onTap: () => _showEditModal(context, uiItems[i]),
+              onRemove: () {
+                context.read<GachaSettingBloc>().add(
+                  RemoveGachaItem(uiItems[i].id),
+                );
+                setState(() {
+                  _hoveredItemId = null;
+                });
+              },
+              onHoverEnter: () => setState(() {
+                _hoveredItemId = uiItems[i].id;
+              }),
+              onHoverExit: () => setState(() {
+                _hoveredItemId = null;
+              }),
+            ),
           // 추가하기 점선 원
           InkWell(
             onTap: () => context.read<GachaSettingBloc>().add(
@@ -1242,540 +1273,6 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildCapsuleItem(DefaultGachaItemData item, bool isMobile) {
-    final double? percentValue = double.tryParse(item.percentStr);
-    final bool needsEdit =
-        item.itemName.trim().isEmpty ||
-        percentValue == null ||
-        percentValue < 0.01 ||
-        percentValue > 100.0;
-
-    final double size = isMobile ? 80.0 : 96.0;
-    final double halfSize = size / 2;
-    final double iconSize = isMobile ? 42.0 : 50.0;
-    final double titleFontSize = isMobile ? 14.0 : 16.0;
-    final double percentFontSize = isMobile ? 12.0 : 14.0;
-
-    return MouseRegion(
-      onEnter: (_) {
-        setState(() {
-          _hoveredItemId = item.id;
-        });
-      },
-      onExit: (_) {
-        setState(() {
-          _hoveredItemId = null;
-        });
-      },
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: <Widget>[
-          InkWell(
-            onTap: () => _showEditModal(context, item),
-            splashColor: Colors.transparent,
-            highlightColor: Colors.transparent,
-            hoverColor: Colors.transparent,
-            customBorder: const CircleBorder(),
-            child: SizedBox(
-              width: size, // 아이템 영역 고정 (오버플로우 방지)
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  Container(
-                    width: size,
-                    height: size,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: _selectedItemId == item.id
-                            ? Colors.orange
-                            : Colors.black,
-                        width: _selectedItemId == item.id ? 3 : 2,
-                        strokeAlign: BorderSide.strokeAlignOutside,
-                      ), // 선택 시 주황색 굵은 선으로 변경
-                    ),
-                    clipBehavior: Clip.antiAlias,
-                    child: Stack(
-                      children: <Widget>[
-                        // 가운데 아이템 이미지 (배경으로 깔림)
-                        Center(
-                          child: item.imageFile != null
-                              ? Image.network(
-                                  item.imageFile!.path,
-                                  width: size,
-                                  height: size,
-                                  fit: BoxFit.cover,
-                                )
-                              : Icon(
-                                  Icons.question_mark,
-                                  size: iconSize,
-                                  color: Colors.black87,
-                                ),
-                        ),
-                        // 상단 (흰색, 반투명)
-                        Positioned(
-                          top: 0,
-                          left: 0,
-                          right: 0,
-                          height: halfSize,
-                          child: Container(
-                            color: Colors.white.withValues(alpha: 0.3),
-                          ),
-                        ),
-                        // 하단 랜덤 색상 반형 디자인 (반투명하게 덮어짐)
-                        Positioned(
-                          bottom: 0,
-                          left: 0,
-                          right: 0,
-                          height: halfSize,
-                          child: Container(
-                            color: item.color.withValues(alpha: 0.7),
-                          ),
-                        ),
-                        // 가운데 분리선
-                        Align(
-                          alignment: Alignment.center,
-                          child: Container(height: 1, color: Colors.black),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    item.itemName.isEmpty ? '제목 없음' : item.itemName,
-                    style: TextStyle(
-                      fontSize: titleFontSize,
-                      fontWeight: FontWeight.bold,
-                      color: item.itemName.isEmpty ? Colors.white38 : Colors.white,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    textAlign: TextAlign.center,
-                  ),
-                  Text(
-                    item.percentOpen ? '(${item.percentStr}%)' : '(미공개)',
-                    style: TextStyle(
-                      fontSize: percentFontSize,
-                      color: Colors.white,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          if (needsEdit)
-            Positioned(
-              top: -6,
-              left: -6,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Colors.orange,
-                  shape: BoxShape.circle,
-                  border: Border.all(color: Colors.white, width: 2),
-                ),
-                padding: const EdgeInsets.all(4),
-                child: const Icon(
-                  Icons.priority_high,
-                  color: Colors.white,
-                  size: 16,
-                ),
-              ),
-            ),
-          if (_hoveredItemId == item.id)
-            Positioned(
-              top: -6,
-              right: -6,
-              child: GestureDetector(
-                onTap: () {
-                  context.read<GachaSettingBloc>().add(
-                    RemoveGachaItem(item.id),
-                  );
-                  setState(() {
-                    _hoveredItemId = null;
-                  });
-                },
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: Colors.red.shade400,
-                    shape: BoxShape.circle,
-                    border: Border.all(color: Colors.white, width: 2),
-                  ),
-                  padding: const EdgeInsets.all(4),
-                  child: const Icon(Icons.close, color: Colors.white, size: 16),
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSettingsSection({required bool isMobile}) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      mainAxisSize: MainAxisSize.min, // Spacer로 인한 에러를 막기 위해 최소 사이즈 적용
-      children: <Widget>[
-        if (!isMobile) const SizedBox(height: 24),
-        Row(
-          children: <Widget>[
-            const Icon(Icons.casino, size: 20, color: Colors.white),
-            const SizedBox(width: 8),
-            const Expanded(
-              child: Text(
-                '뽑기 가능 횟수',
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
-              ),
-            ),
-            const Spacer(),
-            SizedBox(
-              width: 70,
-              child: TextFormField(
-                controller: _playCountController,
-                textAlign: TextAlign.right,
-                keyboardType: TextInputType.number,
-                inputFormatters: <TextInputFormatter>[
-                  FilteringTextInputFormatter.digitsOnly,
-                ],
-                style: const TextStyle(color: Colors.white),
-                decoration: InputDecoration(
-                  filled: true,
-                  fillColor: Colors.white12,
-                  isDense: true,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                    borderSide: const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                    borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                    borderSide: const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: 8),
-            const Text(
-              '회',
-              style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold, color: Colors.white),
-            ),
-          ],
-        ),
-        const SizedBox(height: 6),
-        BlocBuilder<GachaSettingBloc, GachaSettingState>(
-          builder: (BuildContext context, GachaSettingState state) => Text(
-            '최대 ${state.uiItems.length}회 설정 가능 (캡슐 개수 기준)',
-            style: const TextStyle(fontSize: 12, color: Colors.white38),
-            textAlign: TextAlign.end,
-          ),
-        ),
-        const SizedBox(height: 40),
-        const Row(
-          children: <Widget>[
-            Icon(Icons.music_note, size: 20, color: Colors.white),
-            SizedBox(width: 8),
-            Text(
-              'BGM 설정',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
-            ),
-          ],
-        ),
-        const SizedBox(height: 8),
-        Container(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: BlocBuilder<GachaSettingBloc, GachaSettingState>(
-                      builder: (BuildContext context, GachaSettingState state) =>
-                          Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 12),
-                            decoration: BoxDecoration(
-                              color: Colors.white12,
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: DropdownButtonHideUnderline(
-                              child: DropdownButton<String>(
-                                dropdownColor: const Color(0xFF1A1A1A),
-                                style: const TextStyle(color: Colors.white),
-                                iconEnabledColor: Colors.white38,
-                                value: state.selectedBgm,
-                                isExpanded: true,
-                                onChanged: (String? val) {
-                                  if (val != null) {
-                                    context.read<GachaSettingBloc>().add(
-                                      UpdateBgm(val),
-                                    );
-                                  }
-                                },
-                                items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
-                                    .map(
-                                      (String value) => DropdownMenuItem<String>(
-                                        value: value,
-                                        child: Text(
-                                          value,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ),
-                                    )
-                                    .toList(),
-                              ),
-                            ),
-                          ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: Colors.white12,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: const Icon(
-                      Icons.play_arrow,
-                      color: Colors.white38,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-        if (!isMobile) ...<Widget>[
-          const Spacer(),
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.06),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.1), width: 1),
-            ),
-            child: const Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  '⚠️ 포장 완료 조건',
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 13,
-                    color: Colors.deepOrange,
-                  ),
-                ),
-                SizedBox(height: 8),
-                Text(
-                  '• 캡슐 최소 1개 이상 생성',
-                  style: TextStyle(fontSize: 16, color: Colors.white54),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                ),
-                Text(
-                  '• 상단 이름 및 서브타이틀 입력',
-                  style: TextStyle(fontSize: 16, color: Colors.white54),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                ),
-                Text(
-                  '• 뽑기 가능 횟수 최소 1회 이상',
-                  style: TextStyle(fontSize: 16, color: Colors.white54),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                ),
-                Text(
-                  '• 미완성 캡슐 없음',
-                  style: TextStyle(fontSize: 16, color: Colors.white54),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                ),
-                Text(
-                  '• 전체 확률 100% 충족',
-                  style: TextStyle(fontSize: 16, color: Colors.white54),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 16),
-          // 포장 완료 버튼 (데스크톱 최하단 고정)
-          SizedBox(
-            height: 60,
-            child: ElevatedButton(
-              onPressed: _canComplete()
-                  ? () {
-                      _completePackage();
-                    }
-                  : null,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: _canComplete()
-                    ? const Color(0xFF6DE1F1)
-                    : Colors.grey.shade300,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                elevation: 0,
-              ),
-              child: Text(
-                '포장 완료',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  color: _canComplete() ? Colors.black : Colors.grey.shade500,
-                ),
-              ),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-
-  // 모바일 전용 하단 고정 네비게이션 바
-  Widget _buildMobileBottomBar(double totalPercent, int itemCount) {
-    return SafeArea(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-        decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.07),
-          border: const Border(top: BorderSide(color: Colors.white12)),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                const Tooltip(
-                  triggerMode: TooltipTriggerMode.tap,
-                  showDuration: Duration(seconds: 4),
-                  margin: EdgeInsets.symmetric(horizontal: 24),
-                  padding: EdgeInsets.all(12),
-                  textStyle: TextStyle(
-                    color: Colors.white,
-                    fontSize: 13,
-                    height: 1.5,
-                  ),
-                  message:
-                      '⚠️ 포장 완료 조건\n'
-                      '• 캡슐 최소 1개 이상 생성\n'
-                      '• 상단 닉네임 및 서브타이틀 입력\n'
-                      '• 뽑기 가능 횟수 최소 1 이상\n'
-                      '• 미완성 캡슐 없음\n'
-                      '• 전체 확률 100% 충족',
-                  child: Padding(
-                    padding: EdgeInsets.only(right: 8),
-                    child: Icon(
-                      Icons.info_outline,
-                      size: 20,
-                      color: Colors.white38,
-                    ),
-                  ),
-                ),
-                RichText(
-                  text: TextSpan(
-                    style: const TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      fontFamily: 'PFStardust',
-                      color: Colors.white,
-                    ),
-                    children: <InlineSpan>[
-                      const TextSpan(text: '전체 확률 : '),
-                      TextSpan(
-                        text: '${totalPercent.toStringAsFixed(2)}%',
-                        style: TextStyle(
-                          color:
-                              (totalPercent >= 99.99 && totalPercent <= 100.01)
-                              ? Colors.green
-                              : Colors.red,
-                        ),
-                      ),
-                      const TextSpan(text: ' / 100.00%'),
-                      const TextSpan(text: ' [ '),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        child: Image.asset(
-                          'assets/images/gacha.png',
-                          width: 28,
-                          height: 28,
-                        ),
-                      ),
-                      TextSpan(
-                        text: ' : $itemCount개 ]',
-                        style: const TextStyle(color: Colors.white),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              children: <Widget>[
-                InkWell(
-                  onTap: () {
-                    _showMobileSettingsModal(context);
-                  },
-                  borderRadius: BorderRadius.circular(16),
-                  child: Container(
-                    width: 56,
-                    height: 56,
-                    decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.07),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(color: Colors.white.withValues(alpha: 0.15), width: 2),
-                    ),
-                    child: const Icon(Icons.settings, color: Colors.white60),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: SizedBox(
-                    height: 56,
-                    child: ElevatedButton(
-                      onPressed: _canComplete()
-                          ? () {
-                              _completePackage();
-                            }
-                          : null,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: _canComplete()
-                            ? const Color(0xFF6DE1F1)
-                            : Colors.grey.shade300,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        elevation: 0,
-                      ),
-                      child: Text(
-                        '포장 완료',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                          color: _canComplete()
-                              ? Colors.black
-                              : Colors.grey.shade500,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
       ),
     );
   }
@@ -1825,7 +1322,12 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                         ],
                       ),
                       const SizedBox(height: 24),
-                      _buildSettingsSection(isMobile: true),
+                      GachaSettingsPanel(
+                        isMobile: true,
+                        playCountController: _playCountController,
+                        canComplete: _canComplete(),
+                        onComplete: _completePackage,
+                      ),
                       Row(
                         children: <Widget>[
                           Expanded(
@@ -1895,53 +1397,6 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
     );
   }
 
-  Widget _buildStepIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 20.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildCircle(isActive: true, number: '1'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '2'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '3'),
-        ],
-      ),
-    );
-  }
-
-  // 인디케이터 원형 위젯
-  Widget _buildCircle({required bool isActive, required String number}) {
-    return Container(
-      width: 28,
-      height: 28,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: isActive ? AppColors.neonPurple : Colors.white12,
-        border: isActive ? null : Border.all(color: Colors.white24),
-      ),
-      child: Center(
-        child: Text(
-          number,
-          style: TextStyle(
-            color: isActive ? Colors.white : Colors.white38,
-            fontSize: 14,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
-  }
-
-  // 인디케이터 연결 선 위젯
-  Widget _buildLine({required bool isActive}) {
-    return Container(
-      width: 16,
-      height: 2,
-      color: isActive ? AppColors.neonPurple.withValues(alpha: 0.5) : Colors.white12,
-    );
-  }
 }
 
 // 점선 그리기 (빈 아이템용)

--- a/lib/features/addgift/presentation/views/gacha_setting_view.dart
+++ b/lib/features/addgift/presentation/views/gacha_setting_view.dart
@@ -190,12 +190,11 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
       final XFile? pickedFile = await _picker.pickImage(
         source: ImageSource.gallery,
       );
-      if (pickedFile != null) {
-        context.read<GachaSettingBloc>().add(
-          UpdateGachaItemImage(itemData.id, pickedFile),
-        );
-        updateModal(); // 모달 내부 UI 갱신
-      }
+      if (!mounted || pickedFile == null) return;
+      context.read<GachaSettingBloc>().add(
+        UpdateGachaItemImage(itemData.id, pickedFile),
+      );
+      updateModal(); // 모달 내부 UI 갱신
     } catch (e) {
       debugPrint('이미지 선택 오류: $e');
     }
@@ -390,7 +389,7 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                 color: Colors.black,
                 child: PopScope(
                   canPop: false,
-                  onPopInvoked: (bool didPop) {
+                  onPopInvokedWithResult: (bool didPop, Object? result) {
                     if (didPop) return;
                     // 로딩 중에는 뒤로가기 차단
                     if (isLoading) return;

--- a/lib/features/addgift/presentation/views/gacha_setting_view.dart
+++ b/lib/features/addgift/presentation/views/gacha_setting_view.dart
@@ -870,6 +870,7 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                                         totalPercent,
                                         remainPercent,
                                         isMobile,
+                                        gachaState.uiItems,
                                       ),
                                     ],
                                   ),
@@ -886,6 +887,7 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                                         totalPercent,
                                         remainPercent,
                                         isMobile,
+                                        gachaState.uiItems,
                                       ),
                                     ),
                                   ),
@@ -1062,8 +1064,8 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
     double totalPercent,
     double remainPercent,
     bool isMobile,
+    List<DefaultGachaItemData> uiItems,
   ) {
-    final List<DefaultGachaItemData> uiItems = context.read<GachaSettingBloc>().state.uiItems;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -1179,19 +1181,18 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
         ],
         const SizedBox(height: 24),
         if (isMobile)
-          _buildCapsuleListContainer(isMobile: true)
+          _buildCapsuleListContainer(isMobile: true, uiItems: uiItems)
         else
           Expanded(
             child: SingleChildScrollView(
-              child: _buildCapsuleListContainer(isMobile: false),
+              child: _buildCapsuleListContainer(isMobile: false, uiItems: uiItems),
             ),
           ),
       ],
     );
   }
 
-  Widget _buildCapsuleListContainer({required bool isMobile}) {
-    final List<DefaultGachaItemData> uiItems = context.read<GachaSettingBloc>().state.uiItems;
+  Widget _buildCapsuleListContainer({required bool isMobile, required List<DefaultGachaItemData> uiItems}) {
     return Container(
       width: double.infinity, // 부모 너비 가득
       padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
@@ -1496,42 +1497,42 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
               Row(
                 children: <Widget>[
                   Expanded(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      decoration: BoxDecoration(
-                        color: Colors.white12,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: DropdownButtonHideUnderline(
-                        child: DropdownButton<String>(
-                          dropdownColor: const Color(0xFF1A1A1A),
-                          style: const TextStyle(color: Colors.white),
-                          iconEnabledColor: Colors.white38,
-                          value: context
-                              .read<GachaSettingBloc>()
-                              .state
-                              .selectedBgm,
-                          isExpanded: true,
-                          onChanged: (String? val) {
-                            if (val != null) {
-                              context.read<GachaSettingBloc>().add(
-                                UpdateBgm(val),
-                              );
-                            }
-                          },
-                          items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
-                              .map(
-                                (String value) => DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(
-                                    value,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
-                              )
-                              .toList(),
-                        ),
-                      ),
+                    child: BlocBuilder<GachaSettingBloc, GachaSettingState>(
+                      builder: (BuildContext context, GachaSettingState state) =>
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 12),
+                            decoration: BoxDecoration(
+                              color: Colors.white12,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: DropdownButtonHideUnderline(
+                              child: DropdownButton<String>(
+                                dropdownColor: const Color(0xFF1A1A1A),
+                                style: const TextStyle(color: Colors.white),
+                                iconEnabledColor: Colors.white38,
+                                value: state.selectedBgm,
+                                isExpanded: true,
+                                onChanged: (String? val) {
+                                  if (val != null) {
+                                    context.read<GachaSettingBloc>().add(
+                                      UpdateBgm(val),
+                                    );
+                                  }
+                                },
+                                items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
+                                    .map(
+                                      (String value) => DropdownMenuItem<String>(
+                                        value: value,
+                                        child: Text(
+                                          value,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ),
+                                    )
+                                    .toList(),
+                              ),
+                            ),
+                          ),
                     ),
                   ),
                   const SizedBox(width: 8),

--- a/lib/features/addgift/presentation/views/gacha_setting_view.dart
+++ b/lib/features/addgift/presentation/views/gacha_setting_view.dart
@@ -431,8 +431,9 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                             if (!isMobile) const StepIndicator(activeStep: 3),
                           ],
                         ),
-                        body: Stack(
-                          children: <Widget>[
+                        body: SizedBox.expand(
+                          child: Stack(
+                            children: <Widget>[
                             Positioned.fill(
                               child: CustomPaint(
                                 painter: GridBackgroundPainter(),
@@ -553,6 +554,7 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                             ),
                           ],
                         ),
+                      ),
                         // 모바일인 경우 하단 네비게이션 적용 (톱니바퀴 모달 + 완료버튼)
                         bottomNavigationBar: isMobile
                             ? GachaMobileBottomBar(

--- a/lib/features/addgift/presentation/views/gacha_setting_view.dart
+++ b/lib/features/addgift/presentation/views/gacha_setting_view.dart
@@ -9,6 +9,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
+import '../../../../core/widgets/packaging_loading_overlay.dart';
 import '../../application/gacha_setting/gacha_setting_bloc.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../widgets/gacha/gacha_capsule_item.dart';
@@ -929,67 +930,13 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                     ),
 
                     // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
-                    if (isLoading) _buildLoadingOverlay(),
+                    if (isLoading) const PackagingLoadingOverlay(),
                   ],
                 ),
               ));
             },
           );
         },
-      ),
-    );
-  }
-
-  // 반투명 검정 오버레이 위에 프로그레스 인디케이터와 안내 문구를 표시합니다.
-  Widget _buildLoadingOverlay() {
-    return Positioned.fill(
-      child: ColoredBox(
-        color: Colors.black.withValues(alpha: 0.55),
-        child: Center(
-          child: Container(
-            padding: const EdgeInsets.symmetric(vertical: 36, horizontal: 40),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(20),
-              boxShadow: <BoxShadow>[
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.15),
-                  blurRadius: 24,
-                  offset: const Offset(0, 8),
-                ),
-              ],
-            ),
-            child: const Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                SizedBox(
-                  width: 52,
-                  height: 52,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 4,
-                    valueColor: AlwaysStoppedAnimation<Color>(
-                      Color(0xFF6DE1F1),
-                    ),
-                  ),
-                ),
-                SizedBox(height: 24),
-                Text(
-                  '선물을 포장하고 있어요...',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black87,
-                  ),
-                ),
-                SizedBox(height: 8),
-                Text(
-                  '잠시만 기다려 주세요.',
-                  style: TextStyle(fontSize: 13, color: Colors.black45),
-                ),
-              ],
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/lib/features/addgift/presentation/views/gacha_setting_view.dart
+++ b/lib/features/addgift/presentation/views/gacha_setting_view.dart
@@ -12,9 +12,11 @@ import '../../../../core/widgets/grid_background_painter.dart';
 import '../../../../core/widgets/packaging_loading_overlay.dart';
 import '../../application/gacha_setting/gacha_setting_bloc.dart';
 import '../../application/gift_packaging_bloc.dart';
-import '../widgets/gacha/gacha_capsule_item.dart';
+import '../widgets/gacha/gacha_item_edit_form.dart';
+import '../widgets/gacha/gacha_items_section.dart';
 import '../widgets/gacha/gacha_mobile_bottom_bar.dart';
 import '../widgets/gacha/gacha_settings_panel.dart';
+import '../widgets/gacha/gacha_title_bar.dart';
 import '../widgets/step_indicator.dart';
 
 class GachaSettingView extends StatelessWidget {
@@ -23,8 +25,9 @@ class GachaSettingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // GiftPackagingBloc을 주입해서 GachaSettingBloc이 내부에서 직접 SubmitPackage를 dispatch할 수 있도록 합니다.
-    return BlocProvider(
-      create: (BuildContext context) => GachaSettingBloc(context.read<GiftPackagingBloc>()),
+    return BlocProvider<GachaSettingBloc>(
+      create: (BuildContext context) =>
+          GachaSettingBloc(context.read<GiftPackagingBloc>()),
       child: const _GachaSettingContent(),
     );
   }
@@ -55,7 +58,9 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
   @override
   void initState() {
     super.initState();
-    final GiftPackagingState packagingState = context.read<GiftPackagingBloc>().state;
+    final GiftPackagingState packagingState = context
+        .read<GiftPackagingBloc>()
+        .state;
 
     // 이름/서브타이틀 복원
     if (packagingState.receiverName.isNotEmpty) {
@@ -117,7 +122,11 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
       setState(() {});
     });
     _playCountController.addListener(() {
-      final int capsuleCount = context.read<GachaSettingBloc>().state.uiItems.length;
+      final int capsuleCount = context
+          .read<GachaSettingBloc>()
+          .state
+          .uiItems
+          .length;
       final int rawValue = int.tryParse(_playCountController.text) ?? 0;
       if (rawValue > capsuleCount) {
         _playCountController.text = capsuleCount.toString();
@@ -144,7 +153,9 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
   // BLoC 내부에서 데이터를 조합한 뒤 GiftPackagingBloc.SubmitPackage -> _onSubmitPackage -> API 전송 순서로 실행됩니다.
   // 화면 전환은 GiftPackagingBloc의 success 상태를 BlocListener에서 감지해 처리합니다.
   void _completePackage() {
-    final GiftPackagingState packagingState = context.read<GiftPackagingBloc>().state;
+    final GiftPackagingState packagingState = context
+        .read<GiftPackagingBloc>()
+        .state;
 
     context.read<GachaSettingBloc>().add(
       SubmitGachaSetting(
@@ -162,6 +173,12 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
       150 + random.nextInt(106),
       150 + random.nextInt(106),
       150 + random.nextInt(106),
+    );
+  }
+
+  void _addGachaItem() {
+    context.read<GachaSettingBloc>().add(
+      AddGachaItem(color: _getRandomGachaColor()),
     );
   }
 
@@ -207,15 +224,25 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(24.0)),
         ),
-        builder: (BuildContext modalContext) => BlocProvider.value(
-          value: gachaBloc,
-          child: _buildEditForm(
-            modalContext,
-            itemData,
-            _modalNameController!,
-            _modalPercentController!,
-          ),
-        ),
+        builder: (BuildContext modalContext) =>
+            BlocProvider<GachaSettingBloc>.value(
+              value: gachaBloc,
+              child: GachaItemEditForm(
+                modalContext: modalContext,
+                itemData: itemData,
+                nameController: _modalNameController!,
+                percentController: _modalPercentController!,
+                onPickImage: _pickImage,
+                onDeleteItem: (int itemId) {
+                  context.read<GachaSettingBloc>().add(RemoveGachaItem(itemId));
+                  if (_hoveredItemId == itemId) {
+                    setState(() {
+                      _hoveredItemId = null;
+                    });
+                  }
+                },
+              ),
+            ),
       ).then((_) {
         // 하단 모달창이 종료될 때 위젯 트리가 완전히 제거되기 전까지 컨트롤러가 메모리상에서 유지되어야 하므로
         // 여기에 있는 컨트롤러 dispose() 동작을 삭제하고 _modalNameController의 생명주기에 맡깁니다.
@@ -243,13 +270,24 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                   child: SizedBox(
                     width: 480,
                     height: double.infinity,
-                    child: BlocProvider.value(
+                    child: BlocProvider<GachaSettingBloc>.value(
                       value: gachaBloc,
-                      child: _buildEditForm(
-                        context,
-                        itemData,
-                        _modalNameController!,
-                        _modalPercentController!,
+                      child: GachaItemEditForm(
+                        modalContext: context,
+                        itemData: itemData,
+                        nameController: _modalNameController!,
+                        percentController: _modalPercentController!,
+                        onPickImage: _pickImage,
+                        onDeleteItem: (int itemId) {
+                          context.read<GachaSettingBloc>().add(
+                            RemoveGachaItem(itemId),
+                          );
+                          if (_hoveredItemId == itemId) {
+                            setState(() {
+                              _hoveredItemId = null;
+                            });
+                          }
+                        },
                       ),
                     ),
                   ),
@@ -282,477 +320,11 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
     }
   }
 
-  Widget _buildEditForm(
-    BuildContext modalContext,
-    DefaultGachaItemData itemData,
-    TextEditingController nameController,
-    TextEditingController percentController,
-  ) {
-    return StatefulBuilder(
-      builder: (BuildContext context, StateSetter setModalState) {
-        // Bloc 상태를 구독하여 모달 내부를 자동 리빌드하기 위함
-        return BlocBuilder<GachaSettingBloc, GachaSettingState>(
-          builder: (BuildContext context, GachaSettingState state) {
-            // 현재 아이템 데이터를 uiItems에서 찾아옵니다.
-            final DefaultGachaItemData currentItemData = state.uiItems.firstWhere(
-              (DefaultGachaItemData item) => item.id == itemData.id,
-              orElse: () => itemData,
-            );
-
-            void updateModal() {
-              setModalState(() {});
-            }
-
-            final bool isTitleValid = currentItemData.itemName
-                .trim()
-                .isNotEmpty;
-            final double? percentValue = double.tryParse(
-              currentItemData.percentStr,
-            );
-            final bool isPercentValid =
-                percentValue != null &&
-                percentValue >= 0.01 &&
-                percentValue <= 100.0;
-
-            double sumWithoutCurrent = 0.0;
-            for (final DefaultGachaItemData item in state.uiItems) {
-              if (item.id != currentItemData.id) {
-                sumWithoutCurrent += item.percent;
-              }
-            }
-            double rem = 100.0 - sumWithoutCurrent;
-            if (rem < 0) rem = 0.0;
-            String formatPercent(double p) {
-              String s = p.toStringAsFixed(2);
-              if (s.endsWith('.00')) return s.substring(0, s.length - 3);
-              if (s.endsWith('0')) return s.substring(0, s.length - 1);
-              return s;
-            }
-
-            final String remainingStr = formatPercent(rem);
-
-            Widget buildQuickPercentBtn(String value, String label) {
-              return TextButton(
-                onPressed: () {
-                  final String rawVal = value.replaceAll('%', '');
-                  percentController.text = rawVal;
-                  context.read<GachaSettingBloc>().add(
-                    UpdateGachaItemPercent(currentItemData.id, rawVal),
-                  );
-                },
-                style: TextButton.styleFrom(
-                  backgroundColor: AppColors.neonPurple.withValues(alpha: 0.15),
-                  foregroundColor: AppColors.neonPurple,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 8,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-                child: Text(
-                  label,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                ),
-              );
-            }
-
-            return SafeArea(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  Expanded(
-                    child: SingleChildScrollView(
-                      padding: EdgeInsets.only(
-                        left: 32.0,
-                        right: 32.0,
-                        top: 32.0,
-                        bottom: MediaQuery.viewInsetsOf(context).bottom + 32.0,
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: <Widget>[
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: <Widget>[
-                              const SizedBox(width: 24), // 공간 맞추기용
-                              const Text(
-                                '캡슐 상세 설정',
-                                style: TextStyle(
-                                  fontSize: 20,
-                                  fontWeight: FontWeight.bold,
-                                  color: Colors.white,
-                                ),
-                              ),
-                              IconButton(
-                                icon: const Icon(Icons.close, color: Colors.white),
-                                onPressed: () =>
-                                    Navigator.of(modalContext).pop(),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 32),
-                          const Text(
-                            '제목',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          TextFormField(
-                            controller: nameController,
-                            style: const TextStyle(color: Colors.white),
-                            onChanged: (String val) {
-                              context.read<GachaSettingBloc>().add(
-                                UpdateGachaItemName(currentItemData.id, val),
-                              );
-                            },
-                            decoration: InputDecoration(
-                              filled: true,
-                              fillColor: Colors.white12,
-                              suffixIcon: currentItemData.itemName.isNotEmpty
-                                  ? IconButton(
-                                      icon: const Icon(Icons.clear, size: 20, color: Colors.white38),
-                                      onPressed: () {
-                                        nameController.clear();
-                                        context.read<GachaSettingBloc>().add(
-                                          UpdateGachaItemName(
-                                            currentItemData.id,
-                                            '',
-                                          ),
-                                        );
-                                      },
-                                    )
-                                  : null,
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                borderSide: !isTitleValid
-                                    ? const BorderSide(color: Colors.red, width: 1.5)
-                                    : const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-                              ),
-                              enabledBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                borderSide: !isTitleValid
-                                    ? const BorderSide(color: Colors.red, width: 1.5)
-                                    : BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
-                              ),
-                              focusedBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                borderSide: !isTitleValid
-                                    ? const BorderSide(color: Colors.red, width: 1.5)
-                                    : const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-                              ),
-                              errorText: !isTitleValid
-                                  ? '제목은 최소 1글자 이상이어야 합니다.'
-                                  : null,
-                            ),
-                          ),
-                          const SizedBox(height: 24),
-                          const Text(
-                            '이미지',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          if (currentItemData.imageFile == null)
-                            InkWell(
-                              onTap: () =>
-                                  _pickImage(currentItemData, updateModal),
-                              child: Container(
-                                height: 120,
-                                decoration: BoxDecoration(
-                                  color: Colors.white12,
-                                  borderRadius: BorderRadius.circular(12),
-                                  border: Border.all(
-                                    color: Colors.white.withValues(alpha: 0.2),
-                                    width: 1,
-                                  ),
-                                ),
-                                child: const Center(
-                                  child: Icon(
-                                    Icons.add_photo_alternate,
-                                    size: 40,
-                                    color: Colors.white38,
-                                  ),
-                                ),
-                              ),
-                            )
-                          else
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: <Widget>[
-                                Container(
-                                  constraints: const BoxConstraints(
-                                    maxHeight: 500,
-                                  ),
-                                  decoration: BoxDecoration(
-                                    color: Colors.white12,
-                                    borderRadius: BorderRadius.circular(12),
-                                    border: Border.all(
-                                      color: Colors.white.withValues(alpha: 0.2),
-                                      width: 1,
-                                    ),
-                                  ),
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.circular(12),
-                                    child: Image.network(
-                                      currentItemData.imageFile!.path,
-                                      fit: BoxFit.contain,
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(height: 12),
-                                Row(
-                                  mainAxisAlignment: MainAxisAlignment.end,
-                                  children: <Widget>[
-                                    OutlinedButton.icon(
-                                      onPressed: () => _pickImage(
-                                        currentItemData,
-                                        updateModal,
-                                      ),
-                                      icon: const Icon(Icons.edit, size: 16),
-                                      label: const Text('수정'),
-                                      style: OutlinedButton.styleFrom(
-                                        foregroundColor: Colors.blue,
-                                        side: const BorderSide(
-                                          color: Colors.blue,
-                                        ),
-                                      ),
-                                    ),
-                                    const SizedBox(width: 8),
-                                    OutlinedButton.icon(
-                                      onPressed: () {
-                                        context.read<GachaSettingBloc>().add(
-                                          RemoveGachaItemImage(
-                                            currentItemData.id,
-                                          ),
-                                        );
-                                      },
-                                      icon: const Icon(Icons.delete, size: 16),
-                                      label: const Text('삭제'),
-                                      style: OutlinedButton.styleFrom(
-                                        foregroundColor: Colors.red,
-                                        side: const BorderSide(
-                                          color: Colors.red,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          const SizedBox(height: 24),
-                          const Text(
-                            '- 부적절한 제목이나 이미지는 신고 대상이 될 수 있으며, 관련 책임은 등록 주체에게 있음을 알려드립니다.',
-                            style: TextStyle(fontSize: 14, color: Colors.white38),
-                          ),
-                          const SizedBox(height: 24),
-                          const Text(
-                            '확률 (%)',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          TextFormField(
-                            controller: percentController,
-                            keyboardType: const TextInputType.numberWithOptions(
-                              decimal: true,
-                            ),
-                            style: const TextStyle(color: Colors.white),
-                            onChanged: (String val) {
-                              context.read<GachaSettingBloc>().add(
-                                UpdateGachaItemPercent(currentItemData.id, val),
-                              );
-                            },
-                            decoration: InputDecoration(
-                              filled: true,
-                              fillColor: Colors.white12,
-                              suffixIcon: currentItemData.percentStr.isNotEmpty
-                                  ? IconButton(
-                                      icon: const Icon(Icons.clear, size: 20, color: Colors.white38),
-                                      onPressed: () {
-                                        percentController.clear();
-                                        context.read<GachaSettingBloc>().add(
-                                          UpdateGachaItemPercent(
-                                            currentItemData.id,
-                                            '',
-                                          ),
-                                        );
-                                      },
-                                    )
-                                  : null,
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                borderSide: !isPercentValid
-                                    ? const BorderSide(color: Colors.red, width: 1.5)
-                                    : const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-                              ),
-                              enabledBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                borderSide: !isPercentValid
-                                    ? const BorderSide(color: Colors.red, width: 1.5)
-                                    : BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
-                              ),
-                              focusedBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                borderSide: !isPercentValid
-                                    ? const BorderSide(color: Colors.red, width: 1.5)
-                                    : const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-                              ),
-                              errorText: !isPercentValid
-                                  ? '확률은 0.01% 이상 100% 이하입니다.'
-                                  : null,
-                              errorStyle: const TextStyle(fontSize: 14),
-                            ),
-                          ),
-                          const SizedBox(height: 12),
-                          Wrap(
-                            spacing: 8,
-                            runSpacing: 8,
-                            children: <Widget>[
-                              buildQuickPercentBtn(
-                                remainingStr,
-                                '(남은 확률) $remainingStr%',
-                              ),
-                              buildQuickPercentBtn('1', '1%'),
-                              buildQuickPercentBtn('10', '10%'),
-                              buildQuickPercentBtn('50', '50%'),
-                              buildQuickPercentBtn('100', '100%'),
-                            ],
-                          ),
-                          const SizedBox(height: 16),
-                          Row(
-                            children: <Widget>[
-                              Checkbox(
-                                value: currentItemData.percentOpen,
-                                onChanged: (bool? val) {
-                                  context.read<GachaSettingBloc>().add(
-                                    UpdateGachaItemPercentOpen(
-                                      currentItemData.id,
-                                      val ?? false,
-                                    ),
-                                  );
-                                },
-                                activeColor: AppColors.neonPurple,
-                              ),
-                              const Expanded(
-                                child: Text(
-                                  '확률 공개 여부',
-                                  style: TextStyle(
-                                    fontSize: 16,
-                                    color: Colors.white,
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 16),
-                          const Text(
-                            '- 모든 캡슐의 확률 합이 100% 이하여야 합니다.',
-                            style: TextStyle(fontSize: 14, color: Colors.grey),
-                          ),
-                          const SizedBox(height: 40),
-                        ],
-                      ),
-                    ),
-                  ),
-                  // 모달 바닥에 위치하는 버튼 영역 (Bottom Sheet처럼 배치)
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 32,
-                      vertical: 16,
-                    ),
-                    decoration: BoxDecoration(
-                      color: AppColors.darkBg,
-                      border: Border(
-                        top: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
-                      ),
-                    ),
-                    child: Row(
-                      children: <Widget>[
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: () {
-                              Navigator.of(modalContext).pop();
-                              context.read<GachaSettingBloc>().add(
-                                RemoveGachaItem(currentItemData.id),
-                              );
-                              if (_hoveredItemId == currentItemData.id) {
-                                setState(() {
-                                  _hoveredItemId = null;
-                                });
-                              }
-                            },
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: Colors.transparent,
-                              foregroundColor: Colors.red.shade400,
-                              padding: const EdgeInsets.symmetric(vertical: 16),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                                side: BorderSide(
-                                  color: Colors.red.shade400,
-                                  width: 1.5,
-                                ),
-                              ),
-                              elevation: 0,
-                            ),
-                            child: const Text(
-                              '삭제',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: () {
-                              Navigator.of(modalContext).pop();
-                            },
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: AppColors.neonPurple,
-                              foregroundColor: Colors.white,
-                              padding: const EdgeInsets.symmetric(vertical: 16),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              elevation: 0,
-                            ),
-                            child: const Text(
-                              '닫기',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            );
-          },
-        );
-      },
-    );
-  }
-
   // GiftPackagingBloc의 gachaContent를 기반으로 완료 가능 여부를 판단합니다.
   bool _canComplete() {
-    final GiftPackagingState packagingState = context.read<GiftPackagingBloc>().state;
+    final GiftPackagingState packagingState = context
+        .read<GiftPackagingBloc>()
+        .state;
     final GachaContent? gachaContent = packagingState.gachaContent;
 
     if (gachaContent == null || gachaContent.list.isEmpty) return false;
@@ -777,7 +349,8 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
   @override
   Widget build(BuildContext context) {
     return BlocListener<GiftPackagingBloc, GiftPackagingState>(
-      listenWhen: (GiftPackagingState prev, GiftPackagingState curr) => prev.submitStatus != curr.submitStatus,
+      listenWhen: (GiftPackagingState prev, GiftPackagingState curr) =>
+          prev.submitStatus != curr.submitStatus,
       listener: (BuildContext context, GiftPackagingState packagingState) {
         if (packagingState.submitStatus == SubmitStatus.success) {
           // API 전송 성공: 포장 완료 화면으로 이동
@@ -802,12 +375,12 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
               final bool isMobile = MediaQuery.sizeOf(context).width < 800;
 
               // 확률 계산 기준: GiftPackagingBloc의 gachaContent
-              final List<GachaItem> gachaItems = packagingState.gachaContent?.list ?? <GachaItem>[];
+              final List<GachaItem> gachaItems =
+                  packagingState.gachaContent?.list ?? <GachaItem>[];
               final double totalPercent = gachaItems.fold(
                 0.0,
                 (double sum, GachaItem item) => sum + item.percent,
               );
-              final double remainPercent = 100.0 - totalPercent;
 
               final bool isLoading =
                   packagingState.submitStatus == SubmitStatus.loading;
@@ -818,407 +391,191 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
                 child: PopScope(
                   canPop: false,
                   onPopInvoked: (bool didPop) {
-                  if (didPop) return;
-                  // 로딩 중에는 뒤로가기 차단
-                  if (isLoading) return;
-                  if (context.canPop()) {
-                    context.pop();
-                  } else {
-                    context.go('/');
-                  }
-                },
-                child: Stack(
-                  children: <Widget>[
-                    Scaffold(
-                      backgroundColor: AppColors.darkBg,
-                      appBar: AppBar(
-                        toolbarHeight: 68,
+                    if (didPop) return;
+                    // 로딩 중에는 뒤로가기 차단
+                    if (isLoading) return;
+                    if (context.canPop()) {
+                      context.pop();
+                    } else {
+                      context.go('/');
+                    }
+                  },
+                  child: Stack(
+                    children: <Widget>[
+                      Scaffold(
                         backgroundColor: AppColors.darkBg,
-                        surfaceTintColor: Colors.transparent,
-                        elevation: 0,
-                        leading: IconButton(
-                          icon: const Icon(
-                            Icons.arrow_back,
-                            color: Colors.white,
-                          ),
-                          onPressed: isLoading
-                              ? null
-                              : () {
-                                  if (context.canPop()) {
-                                    context.pop();
-                                  } else {
-                                    context.go('/');
-                                  }
-                                },
-                        ),
-                        title: _buildTitleBar(),
-                        actions: <Widget>[if (!isMobile) const StepIndicator(activeStep: 3)],
-                      ),
-                      body: Stack(
-                        children: <Widget>[
-                          Positioned.fill(
-                            child: CustomPaint(
-                              painter: GridBackgroundPainter(),
+                        appBar: AppBar(
+                          toolbarHeight: 68,
+                          backgroundColor: AppColors.darkBg,
+                          surfaceTintColor: Colors.transparent,
+                          elevation: 0,
+                          leading: IconButton(
+                            icon: const Icon(
+                              Icons.arrow_back,
+                              color: Colors.white,
                             ),
+                            onPressed: isLoading
+                                ? null
+                                : () {
+                                    if (context.canPop()) {
+                                      context.pop();
+                                    } else {
+                                      context.go('/');
+                                    }
+                                  },
                           ),
-                          SafeArea(
-                        child: isMobile
-                            ? SingleChildScrollView(
-                                child: Padding(
-                                  padding: const EdgeInsets.all(24.0),
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    children: <Widget>[
-                                      _buildItemsSection(
-                                        totalPercent,
-                                        remainPercent,
-                                        isMobile,
-                                        gachaState.uiItems,
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              )
-                            : Row(
-                                crossAxisAlignment: CrossAxisAlignment.stretch,
-                                children: <Widget>[
-                                  Expanded(
-                                    flex: 7,
-                                    child: Padding(
-                                      padding: const EdgeInsets.all(40.0),
-                                      child: _buildItemsSection(
-                                        totalPercent,
-                                        remainPercent,
-                                        isMobile,
-                                        gachaState.uiItems,
-                                      ),
-                                    ),
-                                  ),
-                                  Container(
-                                    width: 1,
-                                    color: Colors.white.withValues(alpha: 0.1),
-                                  ),
-                                  Expanded(
-                                    flex: 4,
-                                    child: Padding(
-                                      padding: const EdgeInsets.all(40.0),
-                                      child: GachaSettingsPanel(
-                                        isMobile: false,
-                                        playCountController: _playCountController,
-                                        canComplete: _canComplete(),
-                                        onComplete: _completePackage,
-                                      ),
-                                    ),
-                                  ),
-                                ],
+                          title: GachaTitleBar(
+                            userNameController: _userNameController,
+                            subTitleController: _subTitleController,
+                          ),
+                          actions: <Widget>[
+                            if (!isMobile) const StepIndicator(activeStep: 3),
+                          ],
+                        ),
+                        body: Stack(
+                          children: <Widget>[
+                            Positioned.fill(
+                              child: CustomPaint(
+                                painter: GridBackgroundPainter(),
                               ),
-                          ),
-                        ],
-                      ),
-                      // 모바일인 경우 하단 네비게이션 적용 (톱니바퀴 모달 + 완료버튼)
-                      bottomNavigationBar: isMobile
-                          ? GachaMobileBottomBar(
-                              totalPercent: totalPercent,
-                              itemCount: gachaState.uiItems.length,
-                              canComplete: _canComplete(),
-                              onComplete: _completePackage,
-                              onShowSettings: () =>
-                                  _showMobileSettingsModal(context),
-                            )
-                          : null,
-                    ),
-
-                    // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
-                    if (isLoading) const PackagingLoadingOverlay(),
-                  ],
-                ),
-              ));
-            },
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _buildTitleBar() {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: <Widget>[
-        SizedBox(
-          width: 100,
-          child: TextFormField(
-            controller: _userNameController,
-            style: const TextStyle(color: Colors.white),
-            decoration: InputDecoration(
-              hintText: '닉네임',
-              hintStyle: const TextStyle(color: Colors.white38),
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                vertical: 8,
-                horizontal: 12,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.3), width: 1),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        const Text(
-          '님의',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
-        ),
-        const SizedBox(width: 8),
-        SizedBox(
-          width: 120,
-          child: TextFormField(
-            controller: _subTitleController,
-            style: const TextStyle(color: Colors.white),
-            decoration: InputDecoration(
-              hintText: '서브 타이틀',
-              hintStyle: const TextStyle(color: Colors.white38),
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                vertical: 8,
-                horizontal: 12,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.3), width: 1),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(color: Color(0xFF6DE1F1), width: 1.5),
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        const Text(
-          '캡슐 뽑기',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildItemsSection(
-    double totalPercent,
-    double remainPercent,
-    bool isMobile,
-    List<DefaultGachaItemData> uiItems,
-  ) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        if (isMobile) ...<Widget>[
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: <Widget>[
-              ElevatedButton.icon(
-                onPressed: () => context.read<GachaSettingBloc>().add(
-                  AddGachaItem(color: _getRandomGachaColor()),
-                ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.blue,
-                  foregroundColor: Colors.white,
-                  elevation: 0,
-                ),
-                icon: const Icon(Icons.add, size: 18),
-                label: const Text('추가'),
-              ),
-              const SizedBox(width: 8),
-              ElevatedButton.icon(
-                onPressed: () =>
-                    context.read<GachaSettingBloc>().add(RemoveAllGachaItems()),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.red.shade400,
-                  foregroundColor: Colors.white,
-                  elevation: 0,
-                ),
-                icon: const Icon(Icons.delete_outline, size: 18),
-                label: const Text('모두 제거'),
-              ),
-            ],
-          ),
-        ] else ...<Widget>[
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-              Flexible(
-                child: RichText(
-                  overflow: TextOverflow.ellipsis,
-                  text: TextSpan(
-                    style: const TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      fontFamily: 'PFStardust',
-                      color: Colors.white,
-                    ),
-                    children: <InlineSpan>[
-                      const TextSpan(text: '전체 확률 : '),
-                      TextSpan(
-                        text: '${totalPercent.toStringAsFixed(2)}%',
-                        style: TextStyle(
-                          color:
-                              (totalPercent >= 99.99 && totalPercent <= 100.01)
-                              ? Colors.green
-                              : Colors.red,
+                            ),
+                            SafeArea(
+                              child: isMobile
+                                  ? SingleChildScrollView(
+                                      child: Padding(
+                                        padding: const EdgeInsets.all(24.0),
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.stretch,
+                                          children: <Widget>[
+                                            GachaItemsSection(
+                                              totalPercent: totalPercent,
+                                              isMobile: isMobile,
+                                              uiItems: gachaState.uiItems,
+                                              hoveredItemId: _hoveredItemId,
+                                              selectedItemId: _selectedItemId,
+                                              onAddItem: _addGachaItem,
+                                              onRemoveAllItems: () => context
+                                                  .read<GachaSettingBloc>()
+                                                  .add(RemoveAllGachaItems()),
+                                              onTapItem:
+                                                  (DefaultGachaItemData item) =>
+                                                      _showEditModal(
+                                                        context,
+                                                        item,
+                                                      ),
+                                              onRemoveItem: (int itemId) {
+                                                context
+                                                    .read<GachaSettingBloc>()
+                                                    .add(
+                                                      RemoveGachaItem(itemId),
+                                                    );
+                                                setState(() {
+                                                  _hoveredItemId = null;
+                                                });
+                                              },
+                                              onHoverEnter: (int itemId) =>
+                                                  setState(() {
+                                                    _hoveredItemId = itemId;
+                                                  }),
+                                              onHoverExit: () => setState(() {
+                                                _hoveredItemId = null;
+                                              }),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    )
+                                  : Row(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.stretch,
+                                      children: <Widget>[
+                                        Expanded(
+                                          flex: 7,
+                                          child: Padding(
+                                            padding: const EdgeInsets.all(40.0),
+                                            child: GachaItemsSection(
+                                              totalPercent: totalPercent,
+                                              isMobile: isMobile,
+                                              uiItems: gachaState.uiItems,
+                                              hoveredItemId: _hoveredItemId,
+                                              selectedItemId: _selectedItemId,
+                                              onAddItem: _addGachaItem,
+                                              onRemoveAllItems: () => context
+                                                  .read<GachaSettingBloc>()
+                                                  .add(RemoveAllGachaItems()),
+                                              onTapItem:
+                                                  (DefaultGachaItemData item) =>
+                                                      _showEditModal(
+                                                        context,
+                                                        item,
+                                                      ),
+                                              onRemoveItem: (int itemId) {
+                                                context
+                                                    .read<GachaSettingBloc>()
+                                                    .add(
+                                                      RemoveGachaItem(itemId),
+                                                    );
+                                                setState(() {
+                                                  _hoveredItemId = null;
+                                                });
+                                              },
+                                              onHoverEnter: (int itemId) =>
+                                                  setState(() {
+                                                    _hoveredItemId = itemId;
+                                                  }),
+                                              onHoverExit: () => setState(() {
+                                                _hoveredItemId = null;
+                                              }),
+                                            ),
+                                          ),
+                                        ),
+                                        Container(
+                                          width: 1,
+                                          color: Colors.white.withValues(
+                                            alpha: 0.1,
+                                          ),
+                                        ),
+                                        Expanded(
+                                          flex: 4,
+                                          child: Padding(
+                                            padding: const EdgeInsets.all(40.0),
+                                            child: GachaSettingsPanel(
+                                              isMobile: false,
+                                              playCountController:
+                                                  _playCountController,
+                                              canComplete: _canComplete(),
+                                              onComplete: _completePackage,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                            ),
+                          ],
                         ),
+                        // 모바일인 경우 하단 네비게이션 적용 (톱니바퀴 모달 + 완료버튼)
+                        bottomNavigationBar: isMobile
+                            ? GachaMobileBottomBar(
+                                totalPercent: totalPercent,
+                                itemCount: gachaState.uiItems.length,
+                                canComplete: _canComplete(),
+                                onComplete: _completePackage,
+                                onShowSettings: () =>
+                                    _showMobileSettingsModal(context),
+                              )
+                            : null,
                       ),
-                      const TextSpan(text: ' / 100.0%'),
-                      const TextSpan(text: ' [ '),
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        child: Image.asset(
-                          'assets/images/gacha.png',
-                          width: 28,
-                          height: 28,
-                        ),
-                      ),
-                      const TextSpan(
-                        text: ' : ',
-                        style: TextStyle(color: Colors.white),
-                      ),
-                      TextSpan(
-                        text: '${uiItems.length}개 ]',
-                        style: const TextStyle(color: Colors.white),
-                      ),
+
+                      // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
+                      if (isLoading) const PackagingLoadingOverlay(),
                     ],
                   ),
                 ),
-              ),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  ElevatedButton.icon(
-                    onPressed: () => context.read<GachaSettingBloc>().add(
-                      AddGachaItem(color: _getRandomGachaColor()),
-                    ),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.blue,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                    ),
-                    icon: const Icon(Icons.add, size: 18),
-                    label: const Text('추가'),
-                  ),
-                  const SizedBox(width: 8),
-                  ElevatedButton.icon(
-                    onPressed: () => context.read<GachaSettingBloc>().add(
-                      RemoveAllGachaItems(),
-                    ),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.red.shade400,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                    ),
-                    icon: const Icon(Icons.delete_outline, size: 18),
-                    label: const Text('모두 제거'),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ],
-        const SizedBox(height: 24),
-        if (isMobile)
-          _buildCapsuleListContainer(isMobile: true, uiItems: uiItems)
-        else
-          Expanded(
-            child: SingleChildScrollView(
-              child: _buildCapsuleListContainer(isMobile: false, uiItems: uiItems),
-            ),
-          ),
-      ],
-    );
-  }
-
-  Widget _buildCapsuleListContainer({required bool isMobile, required List<DefaultGachaItemData> uiItems}) {
-    return Container(
-      width: double.infinity, // 부모 너비 가득
-      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.05),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.1), width: 1),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Wrap(
-        spacing: 32,
-        runSpacing: 32,
-        children: <Widget>[
-          for (int i = 0; i < uiItems.length; i++)
-            GachaCapsuleItem(
-              item: uiItems[i],
-              isMobile: isMobile,
-              isHovered: _hoveredItemId == uiItems[i].id,
-              isSelected: _selectedItemId == uiItems[i].id,
-              onTap: () => _showEditModal(context, uiItems[i]),
-              onRemove: () {
-                context.read<GachaSettingBloc>().add(
-                  RemoveGachaItem(uiItems[i].id),
-                );
-                setState(() {
-                  _hoveredItemId = null;
-                });
-              },
-              onHoverEnter: () => setState(() {
-                _hoveredItemId = uiItems[i].id;
-              }),
-              onHoverExit: () => setState(() {
-                _hoveredItemId = null;
-              }),
-            ),
-          // 추가하기 점선 원
-          InkWell(
-            onTap: () => context.read<GachaSettingBloc>().add(
-              AddGachaItem(color: _getRandomGachaColor()),
-            ),
-            splashColor: Colors.transparent,
-            highlightColor: Colors.transparent,
-            hoverColor: Colors.transparent,
-            borderRadius: BorderRadius.circular(50),
-            child: Container(
-              width: isMobile ? 80 : 96,
-              height: isMobile ? 80 : 96,
-              decoration: const BoxDecoration(shape: BoxShape.circle),
-              child: Stack(
-                children: <Widget>[
-                  Positioned.fill(
-                    child: CustomPaint(
-                      painter: DashedCirclePainter(
-                        color: Colors.white38,
-                        strokeWidth: 1.5,
-                      ),
-                    ),
-                  ),
-                  const Center(
-                    child: Icon(
-                      Icons.add,
-                      color: Colors.white38,
-                      size: 32,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
+              );
+            },
+          );
+        },
       ),
     );
   }
@@ -1236,7 +593,7 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
       builder: (BuildContext modalContext) {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setModalState) {
-            return BlocProvider.value(
+            return BlocProvider<GachaSettingBloc>.value(
               value: gachaBloc,
               child: Padding(
                 padding: EdgeInsets.only(
@@ -1342,44 +699,4 @@ class _GachaSettingContentState extends State<_GachaSettingContent> {
       },
     );
   }
-
-}
-
-// 점선 그리기 (빈 아이템용)
-class DashedCirclePainter extends CustomPainter {
-  DashedCirclePainter({required this.color, required this.strokeWidth});
-  final Color color;
-  final double strokeWidth;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final Paint paint = Paint()
-      ..color = color
-      ..strokeWidth = strokeWidth
-      ..style = PaintingStyle.stroke;
-
-    final double radius = size.width / 2;
-    final double perimeter = 2 * pi * radius;
-    const double dashLength = 6.0;
-    const double dashSpace = 4.0;
-
-    final int dashCount = (perimeter / (dashLength + dashSpace)).floor();
-    final double sweepAngle = (dashLength / perimeter) * 360 * (pi / 180);
-    final double spaceAngle = (dashSpace / perimeter) * 360 * (pi / 180);
-
-    double currentAngle = 0;
-    for (int i = 0; i < dashCount; i++) {
-      canvas.drawArc(
-        Rect.fromCircle(center: Offset(radius, radius), radius: radius),
-        currentAngle,
-        sweepAngle,
-        false,
-        paint,
-      );
-      currentAngle += sweepAngle + spaceAngle;
-    }
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/lib/features/addgift/presentation/views/gift_delivery_method_view.dart
+++ b/lib/features/addgift/presentation/views/gift_delivery_method_view.dart
@@ -7,6 +7,7 @@ import '../../../../core/constants/app_colors.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../model/gacha_content.dart';
 import '../widgets/addgift_scaffold.dart';
+import '../widgets/step_indicator.dart';
 
 class GiftDeliveryMethodView extends StatelessWidget {
   const GiftDeliveryMethodView({super.key});
@@ -33,7 +34,7 @@ class GiftDeliveryMethodView extends StatelessWidget {
               }
             },
           ),
-          actions: <Widget>[_buildStepIndicator()],
+          actions: <Widget>[const StepIndicator(activeStep: 3)],
         ),
         body: SafeArea(
           child: LayoutBuilder(
@@ -269,52 +270,4 @@ class GiftDeliveryMethodView extends StatelessWidget {
     }
   }
 
-  Widget _buildStepIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 20.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildCircle(isActive: true, number: '1'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '2'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '3'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCircle({required bool isActive, required String number}) {
-    return Container(
-      width: 28,
-      height: 28,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: isActive ? AppColors.neonPurple : Colors.white12,
-        border: isActive ? null : Border.all(color: Colors.white24),
-      ),
-      child: Center(
-        child: Text(
-          number,
-          style: TextStyle(
-            fontFamily: 'WantedSans',
-            color: isActive ? Colors.white : Colors.white38,
-            fontSize: 13,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLine({required bool isActive}) {
-    return Container(
-      width: 16,
-      height: 2,
-      color: isActive
-          ? AppColors.neonPurple.withValues(alpha: 0.5)
-          : Colors.white12,
-    );
-  }
 }

--- a/lib/features/addgift/presentation/views/gift_delivery_method_view.dart
+++ b/lib/features/addgift/presentation/views/gift_delivery_method_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -7,6 +9,8 @@ import '../../../../core/constants/app_colors.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../model/gacha_content.dart';
 import '../widgets/addgift_scaffold.dart';
+import '../widgets/gift_delivery/gift_delivery_main_text.dart';
+import '../widgets/gift_delivery/gift_delivery_options_grid.dart';
 import '../widgets/step_indicator.dart';
 
 class GiftDeliveryMethodView extends StatelessWidget {
@@ -34,7 +38,7 @@ class GiftDeliveryMethodView extends StatelessWidget {
               }
             },
           ),
-          actions: <Widget>[const StepIndicator(activeStep: 3)],
+          actions: const <Widget>[StepIndicator(activeStep: 3)],
         ),
         body: SafeArea(
           child: LayoutBuilder(
@@ -52,13 +56,19 @@ class GiftDeliveryMethodView extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: <Widget>[
-                        Expanded(
-                          child: _buildMainText(TextAlign.left),
+                        const Expanded(
+                          child: GiftDeliveryMainText(
+                            alignment: TextAlign.left,
+                          ),
                         ),
                         const SizedBox(width: 80),
                         Expanded(
                           flex: 2,
-                          child: _buildGridOptions(context, isDesktop: true),
+                          child: GiftDeliveryOptionsGrid(
+                            isDesktop: true,
+                            onTapOption: (String title) =>
+                                _handleOptionTap(context, title),
+                          ),
                         ),
                       ],
                     ),
@@ -72,117 +82,19 @@ class GiftDeliveryMethodView extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
                       const SizedBox(height: 40),
-                      _buildMainText(TextAlign.center),
+                      const GiftDeliveryMainText(alignment: TextAlign.center),
                       const SizedBox(height: 48),
-                      _buildGridOptions(context, isDesktop: false),
+                      GiftDeliveryOptionsGrid(
+                        isDesktop: false,
+                        onTapOption: (String title) =>
+                            _handleOptionTap(context, title),
+                      ),
                       const SizedBox(height: 40),
                     ],
                   ),
                 ),
               );
             },
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildMainText(TextAlign alignment) {
-    return Text(
-      '친구에게 전달할 방식을\n선택해주세요 !',
-      textAlign: alignment,
-      style: const TextStyle(
-        fontFamily: 'PFStardustS',
-        fontSize: 28,
-        color: Colors.white,
-        height: 1.5,
-      ),
-    );
-  }
-
-  Widget _buildGridOptions(BuildContext context, {required bool isDesktop}) {
-    final List<Map<String, dynamic>> options = <Map<String, dynamic>>[
-      <String, dynamic>{
-        'title': '캡슐 뽑기',
-        'icon': 'assets/images/gacha_machine.png',
-        'accent': AppColors.neonPurple,
-      },
-      <String, dynamic>{
-        'title': '문제 맞추기',
-        'icon': 'assets/images/quiz_character.png',
-        'accent': AppColors.neonBlue,
-      },
-      <String, dynamic>{
-        'title': '바로 오픈',
-        'icon': 'assets/images/open_gift_box.png',
-        'accent': AppColors.pixelPurple,
-      },
-    ];
-
-    final int crossAxisCount = isDesktop ? 3 : 2;
-
-    return GridView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: crossAxisCount,
-        mainAxisSpacing: 20,
-        crossAxisSpacing: 20,
-        childAspectRatio: 0.8,
-      ),
-      itemCount: options.length,
-      itemBuilder: (BuildContext context, int index) {
-        return _buildOptionCard(
-          context: context,
-          title: options[index]['title'] as String,
-          iconPath: options[index]['icon'] as String,
-          accent: options[index]['accent'] as Color,
-        );
-      },
-    );
-  }
-
-  Widget _buildOptionCard({
-    required BuildContext context,
-    required String title,
-    required String iconPath,
-    required Color accent,
-  }) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: () => _handleOptionTap(context, title),
-        borderRadius: BorderRadius.circular(20),
-        child: Container(
-          decoration: BoxDecoration(
-            color: accent.withValues(alpha: 0.07),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
-              color: accent.withValues(alpha: 0.4),
-              width: 1.5,
-            ),
-          ),
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Expanded(
-                child: Center(
-                  child: Image.asset(iconPath, fit: BoxFit.contain),
-                ),
-              ),
-              const SizedBox(height: 12),
-              Text(
-                title,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontFamily: 'WantedSans',
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: accent,
-                ),
-              ),
-            ],
           ),
         ),
       ),
@@ -262,12 +174,13 @@ class GiftDeliveryMethodView extends StatelessWidget {
       if (confirm == true) {
         bloc.add(SetGachaContent(const GachaContent()));
         bloc.add(SetContentType(selectedType));
-        if (context.mounted) context.push(route);
+        if (context.mounted) {
+          unawaited(context.push(route));
+        }
       }
     } else {
       bloc.add(SetContentType(selectedType));
-      context.push(route);
+      unawaited(context.push(route));
     }
   }
-
 }

--- a/lib/features/addgift/presentation/views/memory_decision_view.dart
+++ b/lib/features/addgift/presentation/views/memory_decision_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gifo/features/addgift/model/gallery_item.dart';
@@ -7,6 +9,8 @@ import '../../../../core/constants/app_breakpoints.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../widgets/addgift_scaffold.dart';
+import '../widgets/memory_decision/memory_decision_buttons_column.dart';
+import '../widgets/memory_decision/memory_decision_main_text.dart';
 import '../widgets/step_indicator.dart';
 
 class MemoryDecisionView extends StatelessWidget {
@@ -34,7 +38,7 @@ class MemoryDecisionView extends StatelessWidget {
               }
             },
           ),
-          actions: <Widget>[const StepIndicator(activeStep: 2)],
+          actions: const <Widget>[StepIndicator(activeStep: 2)],
         ),
         body: SafeArea(
           child: LayoutBuilder(
@@ -52,11 +56,23 @@ class MemoryDecisionView extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: <Widget>[
-                        Expanded(
-                          child: _buildMainText(TextAlign.left),
+                        const Expanded(
+                          child: MemoryDecisionMainText(
+                            alignment: TextAlign.left,
+                          ),
                         ),
                         const SizedBox(width: 80),
-                        Expanded(child: _buildButtonsColumn(context)),
+                        Expanded(
+                          child: MemoryDecisionButtonsColumn(
+                            onSelectShareMemory: () {
+                              unawaited(
+                                context.push('/addgift/memory-gallery'),
+                              );
+                            },
+                            onSelectDirectOpen: () =>
+                                _handleDirectOpenSelection(context),
+                          ),
+                        ),
                       ],
                     ),
                   ),
@@ -72,10 +88,20 @@ class MemoryDecisionView extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: <Widget>[
                           const SizedBox(height: 48),
-                          _buildMainText(TextAlign.center),
+                          const MemoryDecisionMainText(
+                            alignment: TextAlign.center,
+                          ),
                           const Spacer(),
                           const SizedBox(height: 48),
-                          _buildButtonsColumn(context),
+                          MemoryDecisionButtonsColumn(
+                            onSelectShareMemory: () {
+                              unawaited(
+                                context.push('/addgift/memory-gallery'),
+                              );
+                            },
+                            onSelectDirectOpen: () =>
+                                _handleDirectOpenSelection(context),
+                          ),
                         ],
                       ),
                     ),
@@ -89,165 +115,73 @@ class MemoryDecisionView extends StatelessWidget {
     );
   }
 
-  Widget _buildMainText(TextAlign alignment) {
-    return Text(
-      '선물을 공개하기 전,\n친구와 추억을 공유할까요?',
-      textAlign: alignment,
-      style: const TextStyle(
-        fontFamily: 'PFStardustS',
-        fontSize: 28,
-        color: Colors.white,
-        height: 1.5,
-      ),
-    );
-  }
+  Future<void> _handleDirectOpenSelection(BuildContext context) async {
+    final bool hasGalleryData = context
+        .read<GiftPackagingBloc>()
+        .state
+        .gallery
+        .isNotEmpty;
 
-  Widget _buildButtonsColumn(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        _buildSelectionButton(
-          title: '네,',
-          subtitle: '저는 친구와 함께 추억을 공유하고 싶어요!',
-          icon: Icons.photo_library_rounded,
-          accentColor: AppColors.neonPurple,
-          onPressed: () => context.push('/addgift/memory-gallery'),
-        ),
-        const SizedBox(height: 16),
-        _buildSelectionButton(
-          title: '아니요,',
-          subtitle: '저는 바로 선물을 공개할거에요.',
-          icon: Icons.card_giftcard_rounded,
-          accentColor: AppColors.neonBlue,
-          onPressed: () async {
-            final bool hasGalleryData = context
-                .read<GiftPackagingBloc>()
-                .state
-                .gallery
-                .isNotEmpty;
-
-            if (hasGalleryData) {
-              final bool? confirm = await showDialog<bool>(
-                context: context,
-                builder: (BuildContext dialogContext) => AlertDialog(
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  backgroundColor: const Color(0xFF1A1A1A),
-                  title: const Text(
-                    '추억 갤러리 데이터 존재',
-                    style: TextStyle(
-                      fontFamily: 'WantedSans',
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                    ),
-                  ),
-                  content: const Text(
-                    '등록된 추억 갤러리 데이터가 있습니다.\n초기화하고 바로 선물 공개로 진행할까요?',
-                    style: TextStyle(
-                      fontFamily: 'WantedSans',
-                      height: 1.5,
-                      fontSize: 15,
-                      color: Colors.white70,
-                    ),
-                  ),
-                  actions: <Widget>[
-                    TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(false),
-                      child: const Text(
-                        '아니오 (데이터 유지)',
-                        style: TextStyle(
-                          fontFamily: 'WantedSans',
-                          color: Colors.white38,
-                        ),
-                      ),
-                    ),
-                    TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(true),
-                      child: const Text(
-                        '초기화 후 진행',
-                        style: TextStyle(
-                          fontFamily: 'WantedSans',
-                          color: Colors.redAccent,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              );
-              if (confirm == true && context.mounted) {
-                context.read<GiftPackagingBloc>().add(
-                  SetGalleryItems(<GalleryItem>[]),
-                );
-                context.push('/addgift/delivery-method');
-              } else if (confirm == false && context.mounted) {
-                context.push('/addgift/delivery-method');
-              }
-            } else {
-              context.push('/addgift/delivery-method');
-            }
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget _buildSelectionButton({
-    required String title,
-    required String subtitle,
-    required IconData icon,
-    required Color accentColor,
-    required VoidCallback onPressed,
-  }) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: onPressed,
-        borderRadius: BorderRadius.circular(20.0),
-        child: Container(
-          padding: const EdgeInsets.symmetric(vertical: 28.0, horizontal: 16.0),
-          decoration: BoxDecoration(
-            color: accentColor.withValues(alpha: 0.07),
-            border: Border.all(
-              color: accentColor.withValues(alpha: 0.5),
-              width: 1.5,
+    if (hasGalleryData) {
+      final bool? confirm = await showDialog<bool>(
+        context: context,
+        builder: (BuildContext dialogContext) => AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          backgroundColor: const Color(0xFF1A1A1A),
+          title: const Text(
+            '추억 갤러리 데이터 존재',
+            style: TextStyle(
+              fontFamily: 'WantedSans',
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
             ),
-            borderRadius: BorderRadius.circular(20.0),
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Icon(icon, size: 48, color: accentColor),
-              const SizedBox(height: 20),
-              Text(
-                title,
-                textAlign: TextAlign.center,
+          content: const Text(
+            '등록된 추억 갤러리 데이터가 있습니다.\n초기화하고 바로 선물 공개로 진행할까요?',
+            style: TextStyle(
+              fontFamily: 'WantedSans',
+              height: 1.5,
+              fontSize: 15,
+              color: Colors.white70,
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text(
+                '아니오 (데이터 유지)',
                 style: TextStyle(
-                  fontFamily: 'PFStardustS',
-                  fontSize: 22,
-                  color: accentColor,
-                  height: 1.3,
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                subtitle,
-                textAlign: TextAlign.center,
-                style: const TextStyle(
                   fontFamily: 'WantedSans',
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
-                  height: 1.5,
-                  color: Colors.white60,
+                  color: Colors.white38,
                 ),
               ),
-            ],
-          ),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text(
+                '초기화 후 진행',
+                style: TextStyle(
+                  fontFamily: 'WantedSans',
+                  color: Colors.redAccent,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
         ),
-      ),
-    );
-  }
+      );
 
+      if (confirm == true && context.mounted) {
+        context.read<GiftPackagingBloc>().add(SetGalleryItems(<GalleryItem>[]));
+        unawaited(context.push('/addgift/delivery-method'));
+      } else if (confirm == false && context.mounted) {
+        unawaited(context.push('/addgift/delivery-method'));
+      }
+      return;
+    }
+
+    unawaited(context.push('/addgift/delivery-method'));
+  }
 }

--- a/lib/features/addgift/presentation/views/memory_decision_view.dart
+++ b/lib/features/addgift/presentation/views/memory_decision_view.dart
@@ -7,6 +7,7 @@ import '../../../../core/constants/app_breakpoints.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../widgets/addgift_scaffold.dart';
+import '../widgets/step_indicator.dart';
 
 class MemoryDecisionView extends StatelessWidget {
   const MemoryDecisionView({super.key});
@@ -33,7 +34,7 @@ class MemoryDecisionView extends StatelessWidget {
               }
             },
           ),
-          actions: <Widget>[_buildStepIndicator()],
+          actions: <Widget>[const StepIndicator(activeStep: 2)],
         ),
         body: SafeArea(
           child: LayoutBuilder(
@@ -249,50 +250,4 @@ class MemoryDecisionView extends StatelessWidget {
     );
   }
 
-  Widget _buildStepIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 20.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildCircle(isActive: true, number: '1'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '2'),
-          _buildLine(isActive: false),
-          _buildCircle(isActive: false, number: '3'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCircle({required bool isActive, required String number}) {
-    return Container(
-      width: 28,
-      height: 28,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: isActive ? AppColors.neonPurple : Colors.white12,
-        border: isActive ? null : Border.all(color: Colors.white24),
-      ),
-      child: Center(
-        child: Text(
-          number,
-          style: TextStyle(
-            fontFamily: 'WantedSans',
-            color: isActive ? Colors.white : Colors.white38,
-            fontSize: 13,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLine({required bool isActive}) {
-    return Container(
-      width: 16,
-      height: 2,
-      color: isActive ? AppColors.neonPurple.withValues(alpha: 0.5) : Colors.white12,
-    );
-  }
 }

--- a/lib/features/addgift/presentation/views/memory_gallery_setting_view.dart
+++ b/lib/features/addgift/presentation/views/memory_gallery_setting_view.dart
@@ -11,6 +11,7 @@ import '../../../../core/constants/app_colors.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+import '../widgets/step_indicator.dart';
 
 class MemoryGallerySettingView extends StatelessWidget {
   const MemoryGallerySettingView({super.key});
@@ -232,7 +233,7 @@ class _MemoryGallerySettingViewState
               },
             ),
             // 데스크톱에서만 appbar에 진행도 표시
-            actions: <Widget>[if (!isMobile) _buildStepIndicator()],
+            actions: <Widget>[if (!isMobile) const StepIndicator(activeStep: 2)],
           ),
           body: Stack(
             children: <Widget>[
@@ -1129,54 +1130,6 @@ class _MemoryGallerySettingViewState
     );
   }
 
-  Widget _buildStepIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 20.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildCircle(isActive: true, number: '1'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '2'),
-          _buildLine(isActive: false),
-          _buildCircle(isActive: false, number: '3'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCircle({required bool isActive, required String number}) {
-    return Container(
-      width: 28,
-      height: 28,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: isActive ? AppColors.neonPurple : Colors.white12,
-        border: isActive ? null : Border.all(color: Colors.white24),
-      ),
-      child: Center(
-        child: Text(
-          number,
-          style: TextStyle(
-            fontFamily: 'WantedSans',
-            color: isActive ? Colors.white : Colors.white38,
-            fontSize: 13,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLine({required bool isActive}) {
-    return Container(
-      width: 16,
-      height: 2,
-      color: isActive
-          ? AppColors.neonPurple.withValues(alpha: 0.5)
-          : Colors.white12,
-    );
-  }
 }
 
 // ------------------------------------------------------------------

--- a/lib/features/addgift/presentation/views/memory_gallery_setting_view.dart
+++ b/lib/features/addgift/presentation/views/memory_gallery_setting_view.dart
@@ -11,6 +11,9 @@ import '../../../../core/constants/app_colors.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+import '../widgets/memory_gallery/memory_desktop_card.dart';
+import '../widgets/memory_gallery/memory_edit_form.dart';
+import '../widgets/memory_gallery/memory_mobile_card.dart';
 import '../widgets/step_indicator.dart';
 
 class MemoryGallerySettingView extends StatelessWidget {
@@ -108,7 +111,7 @@ class _MemoryGallerySettingViewState
         ),
         builder: (BuildContext modalContext) => BlocProvider.value(
           value: memoryBloc,
-          child: _MemoryEditForm(
+          child: MemoryEditForm(
             itemId: itemData.id,
             onPickImage: () => _pickImage(itemData.id),
           ),
@@ -141,7 +144,7 @@ class _MemoryGallerySettingViewState
                     height: double.infinity,
                     child: BlocProvider.value(
                       value: memoryBloc,
-                      child: _MemoryEditForm(
+                      child: MemoryEditForm(
                         itemId: itemData.id,
                         onPickImage: () => _pickImage(itemData.id),
                       ),
@@ -468,12 +471,28 @@ class _MemoryGallerySettingViewState
                           }
                           final MemoryGalleryItemData item =
                               galleryState.uiItems[index];
-                          return _buildDesktopCard(
+                          return MemoryDesktopCard(
                             key: ValueKey<int>(item.id),
                             index: index,
                             itemData: item,
-                            selectedItemId: galleryState.selectedItemId,
-                            hoveredItemId: galleryState.hoveredItemId,
+                            isIncomplete: _isItemIncomplete(item),
+                            isSelected: galleryState.selectedItemId == item.id,
+                            isHovered: galleryState.hoveredItemId == item.id,
+                            onTap: () => _showEditModal(context, item),
+                            onRemove: () {
+                              context.read<MemoryGallerySettingBloc>().add(
+                                RemoveMemoryItem(item.id),
+                              );
+                              context.read<MemoryGallerySettingBloc>().add(
+                                const ClearHoverMemoryItem(),
+                              );
+                            },
+                            onHoverEnter: () => context
+                                .read<MemoryGallerySettingBloc>()
+                                .add(HoverMemoryItem(item.id)),
+                            onHoverExit: () => context
+                                .read<MemoryGallerySettingBloc>()
+                                .add(const ClearHoverMemoryItem()),
                           );
                         },
                       ),
@@ -488,179 +507,6 @@ class _MemoryGallerySettingViewState
     );
   }
 
-  // 데스크톱 카드: Column 정렬 (이미지 상단, 텍스트 하단), 그리드 셀에 맞춰짐
-  Widget _buildDesktopCard({
-    required Key key,
-    required int index,
-    required MemoryGalleryItemData itemData,
-    required int? selectedItemId,
-    required int? hoveredItemId,
-  }) {
-    final bool isIncomplete = _isItemIncomplete(itemData);
-    final bool isHovered = hoveredItemId == itemData.id;
-
-    return MouseRegion(
-      key: key,
-      onEnter: (_) => context.read<MemoryGallerySettingBloc>().add(
-        HoverMemoryItem(itemData.id),
-      ),
-      onExit: (_) => context.read<MemoryGallerySettingBloc>().add(
-        const ClearHoverMemoryItem(),
-      ),
-      child: ReorderableDragStartListener(
-        index: index,
-        child: Container(
-          // Grid의 여백을 활용하므로 별도의 외부 bottom margin은 주지 않음
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: <Widget>[
-              // 배경 (카드 본체)
-              Positioned.fill(
-                child: Material(
-                  color: Colors.white.withValues(alpha: 0.05),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16.0),
-                    side: BorderSide(
-                      color: selectedItemId == itemData.id
-                          ? AppColors.neonPurple
-                          : Colors.white24,
-                      width: selectedItemId == itemData.id ? 2.5 : 1.0,
-                    ),
-                  ),
-                  clipBehavior: Clip.antiAlias,
-                  child: InkWell(
-                    onTap: () => _showEditModal(context, itemData),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 20.0,
-                        vertical: 24.0,
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: <Widget>[
-                          // 썸네일 이미지
-                          Expanded(
-                            child: Container(
-                              width: double.infinity,
-                              clipBehavior: Clip.antiAlias,
-                              decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.08),
-                                borderRadius: BorderRadius.circular(12.0),
-                              ),
-                              child: itemData.imageFile != null
-                                  ? Image.network(
-                                      itemData.imageFile!.path,
-                                      fit: BoxFit.cover,
-                                    )
-                                  : Icon(
-                                      Icons.photo,
-                                      size: 40,
-                                      color: Colors.grey.shade300,
-                                    ),
-                            ),
-                          ),
-                          const SizedBox(height: 20),
-                          // 하단 텍스트 영역
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              Text(
-                                itemData.title.isEmpty
-                                    ? '제목 없음'
-                                    : itemData.title,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: TextStyle(
-                                  fontFamily: 'WantedSans',
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.bold,
-                                  color: itemData.title.isEmpty
-                                      ? Colors.white38
-                                      : Colors.white,
-                                ),
-                              ),
-                              const SizedBox(height: 12),
-                              Text(
-                                itemData.description.isEmpty
-                                    ? '설명 없음'
-                                    : itemData.description,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: TextStyle(
-                                  fontFamily: 'WantedSans',
-                                  fontSize: 14,
-                                  height: 1.5,
-                                  color: itemData.description.isEmpty
-                                      ? Colors.white38
-                                      : Colors.white70,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-
-              // 불완전 아이템 경고 아이콘 (좌측 상단, Stack 최상단)
-              if (isIncomplete)
-                Positioned(
-                  top: -6,
-                  left: -6,
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: Colors.orange,
-                      shape: BoxShape.circle,
-                      border: Border.all(color: Colors.white, width: 2),
-                    ),
-                    padding: const EdgeInsets.all(4),
-                    child: const Icon(
-                      Icons.priority_high,
-                      color: Colors.white,
-                      size: 16,
-                    ),
-                  ),
-                ),
-
-              // hover 시 삭제 버튼 (우측 상단 튀어나오게, 드래그 무시하기 위해 제어)
-              if (isHovered)
-                Positioned(
-                  top: -6,
-                  right: -6,
-                  child: GestureDetector(
-                    onTap: () {
-                      context.read<MemoryGallerySettingBloc>().add(
-                        RemoveMemoryItem(itemData.id),
-                      );
-                      context.read<MemoryGallerySettingBloc>().add(
-                        const ClearHoverMemoryItem(),
-                      );
-                    },
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: Colors.red.shade400,
-                        shape: BoxShape.circle,
-                        border: Border.all(color: Colors.white, width: 2),
-                      ),
-                      padding: const EdgeInsets.all(4),
-                      child: const Icon(
-                        Icons.close,
-                        color: Colors.white,
-                        size: 16,
-                      ),
-                    ),
-                  ),
-                ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  // 데스크톱 추가 카드 (리스트 마지막 자리에 배치, 전체 너비)
   Widget _buildDesktopAddCard() {
     return OutlinedButton(
       style: OutlinedButton.styleFrom(
@@ -878,12 +724,17 @@ class _MemoryGallerySettingViewState
                   itemBuilder: (BuildContext context, int index) {
                     final MemoryGalleryItemData item =
                         galleryState.uiItems[index];
-                    return _buildMobileCard(
+                    return MemoryMobileCard(
                       key: ValueKey<int>(item.id),
                       index: index,
                       itemData: item,
-                      selectedItemId: galleryState.selectedItemId,
-                      itemCount: galleryState.uiItems.length,
+                      isIncomplete: _isItemIncomplete(item),
+                      isSelected: galleryState.selectedItemId == item.id,
+                      onTap: () => _showEditModal(context, item),
+                      onRemove: () =>
+                          context.read<MemoryGallerySettingBloc>().add(
+                            RemoveMemoryItem(item.id),
+                          ),
                     );
                   },
                 ),
@@ -891,151 +742,6 @@ class _MemoryGallerySettingViewState
             ),
           ),
       ],
-    );
-  }
-
-  // 모바일 카드 (기존 형태 유지)
-  Widget _buildMobileCard({
-    required Key key,
-    required int index,
-    required MemoryGalleryItemData itemData,
-    required int? selectedItemId,
-    required int itemCount,
-  }) {
-    final bool isIncomplete = _isItemIncomplete(itemData);
-
-    return Container(
-      key: key,
-      margin: const EdgeInsets.only(bottom: 16.0),
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: <Widget>[
-          Material(
-            color: Colors.white.withValues(alpha: 0.05),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(16.0),
-              side: BorderSide(
-                color: selectedItemId == itemData.id
-                    ? AppColors.neonPurple
-                    : Colors.white24,
-                width: selectedItemId == itemData.id ? 2.0 : 1.0,
-              ),
-            ),
-            clipBehavior: Clip.antiAlias,
-            child: InkWell(
-              onTap: () => _showEditModal(context, itemData),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16.0,
-                  vertical: 16.0,
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    ReorderableDragStartListener(
-                      index: index,
-                      child: const Padding(
-                        padding: EdgeInsets.fromLTRB(0, 8, 12, 8),
-                        child: Icon(Icons.drag_handle, color: Colors.grey),
-                      ),
-                    ),
-                    Container(
-                      width: 80,
-                      height: 80,
-                      clipBehavior: Clip.antiAlias,
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFF8F9FA),
-                        borderRadius: BorderRadius.circular(12.0),
-                      ),
-                      child: itemData.imageFile != null
-                          ? Image.network(
-                              itemData.imageFile!.path,
-                              fit: BoxFit.cover,
-                            )
-                          : Icon(
-                              Icons.photo,
-                              size: 30,
-                              color: Colors.grey.shade300,
-                            ),
-                    ),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: <Widget>[
-                          Text(
-                            itemData.title.isEmpty ? '제목 없음' : itemData.title,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              fontFamily: 'WantedSans',
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                              color: itemData.title.isEmpty
-                                  ? Colors.white38
-                                  : Colors.white,
-                            ),
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            itemData.description.isEmpty
-                                ? '설명 없음'
-                                : itemData.description,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              fontFamily: 'WantedSans',
-                              fontSize: 13,
-                              color: itemData.description.isEmpty
-                                  ? Colors.white38
-                                  : Colors.white70,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    IconButton(
-                      icon: const Icon(
-                        Icons.close,
-                        color: Colors.grey,
-                        size: 20,
-                      ),
-                      onPressed: () {
-                        context.read<MemoryGallerySettingBloc>().add(
-                          RemoveMemoryItem(itemData.id),
-                        );
-                      },
-                      padding: EdgeInsets.zero,
-                      constraints: const BoxConstraints(),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-
-          // 불완전 아이템 경고 아이콘: Stack 마지막에 배치하여 드래그 테두리보다 위에 표시
-          if (isIncomplete)
-            Positioned(
-              top: -6,
-              left: -6,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Colors.orange,
-                  shape: BoxShape.circle,
-                  border: Border.all(color: Colors.white, width: 2),
-                ),
-                padding: const EdgeInsets.all(4),
-                child: const Icon(
-                  Icons.priority_high,
-                  color: Colors.white,
-                  size: 16,
-                ),
-              ),
-            ),
-        ],
-      ),
     );
   }
 
@@ -1130,375 +836,4 @@ class _MemoryGallerySettingViewState
     );
   }
 
-}
-
-// ------------------------------------------------------------------
-// 편집 모달 전용 위젯 (BlocBuilder로 실시간 상태 반영)
-// ------------------------------------------------------------------
-class _MemoryEditForm extends StatelessWidget {
-  final int itemId;
-  final VoidCallback onPickImage;
-
-  const _MemoryEditForm({required this.itemId, required this.onPickImage});
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<MemoryGallerySettingBloc, MemoryGallerySettingState>(
-      builder: (BuildContext context, MemoryGallerySettingState state) {
-        final MemoryGalleryItemData? itemData = state.uiItems
-            .where((MemoryGalleryItemData item) => item.id == itemId)
-            .firstOrNull;
-
-        if (itemData == null) return const SizedBox.shrink();
-
-        final bool isTitleValid = itemData.title.trim().isNotEmpty;
-        final bool isDescriptionValid = itemData.description.trim().isNotEmpty;
-        final bool hasImage = itemData.imageFile != null;
-
-        return SafeArea(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: EdgeInsets.only(
-                    left: 32.0,
-                    right: 32.0,
-                    top: 32.0,
-                    bottom: MediaQuery.viewInsetsOf(context).bottom + 32.0,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      // 헤더: 제목 + 닫기 버튼
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: <Widget>[
-                          const SizedBox(width: 24),
-                          const Text(
-                            '추억 상세 설정',
-                            style: TextStyle(
-                              fontFamily: 'WantedSans',
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
-                            ),
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.close, color: Colors.white70),
-                            onPressed: () => Navigator.of(context).pop(),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 32),
-
-                      // 제목 입력 영역
-                      const Text(
-                        '제목',
-                        style: TextStyle(
-                          fontFamily: 'WantedSans',
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      TextFormField(
-                        key: ValueKey<String>('title_$itemId'),
-                        initialValue: itemData.title,
-                        style: const TextStyle(color: Colors.white),
-                        onChanged: (String val) {
-                          context.read<MemoryGallerySettingBloc>().add(
-                            UpdateMemoryItemTitle(itemId, val),
-                          );
-                        },
-                        decoration: InputDecoration(
-                          filled: true,
-                          fillColor: Colors.white.withValues(alpha: 0.07),
-                          hintText: '제목을 입력해주세요',
-                          hintStyle: const TextStyle(color: Colors.white38),
-                          suffixIcon: itemData.title.isNotEmpty
-                              ? IconButton(
-                                  icon: const Icon(Icons.clear, size: 20),
-                                  onPressed: () {
-                                    context
-                                        .read<MemoryGallerySettingBloc>()
-                                        .add(UpdateMemoryItemTitle(itemId, ''));
-                                  },
-                                )
-                              : null,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide: BorderSide(
-                              color: isTitleValid
-                                  ? const Color(0xFF6DE1F1)
-                                  : Colors.red,
-                              width: 1.5,
-                            ),
-                          ),
-                          enabledBorder: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide: BorderSide(
-                              color: isTitleValid
-                                  ? Colors.white24
-                                  : Colors.red,
-                              width: isTitleValid ? 1.0 : 1.5,
-                            ),
-                          ),
-                          focusedBorder: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide: BorderSide(
-                              color: isTitleValid
-                                  ? AppColors.neonPurple
-                                  : Colors.red,
-                              width: 1.5,
-                            ),
-                          ),
-                          errorText: !isTitleValid
-                              ? '제목은 최소 1글자 이상이어야 합니다.'
-                              : null,
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-
-                      // 이미지 선택 영역
-                      const Text(
-                        '이미지',
-                        style: TextStyle(
-                          fontFamily: 'WantedSans',
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      if (!hasImage)
-                        InkWell(
-                          onTap: onPickImage,
-                          child: Container(
-                            height: 120,
-                            decoration: BoxDecoration(
-                              color: Colors.white.withValues(alpha: 0.07),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: Colors.white24,
-                                width: 1,
-                              ),
-                            ),
-                            child: const Center(
-                              child: Icon(
-                                Icons.add_photo_alternate,
-                                size: 40,
-                                color: Colors.white38,
-                              ),
-                            ),
-                          ),
-                        )
-                      else
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: <Widget>[
-                            Container(
-                              constraints: const BoxConstraints(maxHeight: 500),
-                              decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.05),
-                                borderRadius: BorderRadius.circular(12),
-                                border: Border.all(
-                                  color: Colors.white24,
-                                  width: 1,
-                                ),
-                              ),
-                              child: ClipRRect(
-                                borderRadius: BorderRadius.circular(12),
-                                child: Image.network(
-                                  itemData.imageFile!.path,
-                                  fit: BoxFit.contain,
-                                ),
-                              ),
-                            ),
-                            const SizedBox(height: 12),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.end,
-                              children: <Widget>[
-                                OutlinedButton.icon(
-                                  onPressed: onPickImage,
-                                  icon: const Icon(Icons.edit, size: 16),
-                                  label: const Text('수정'),
-                                  style: OutlinedButton.styleFrom(
-                                    foregroundColor: AppColors.neonBlue,
-                                    side: BorderSide(
-                                      color: AppColors.neonBlue,
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(width: 8),
-                                OutlinedButton.icon(
-                                  onPressed: () {
-                                    context
-                                        .read<MemoryGallerySettingBloc>()
-                                        .add(RemoveMemoryItemImage(itemId));
-                                  },
-                                  icon: const Icon(Icons.delete, size: 16),
-                                  label: const Text('삭제'),
-                                  style: OutlinedButton.styleFrom(
-                                    foregroundColor: Colors.redAccent,
-                                    side: const BorderSide(
-                                      color: Colors.redAccent,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      const SizedBox(height: 8),
-
-                      // 부적절한 콘텐츠 주의 안내 (gacha_setting_view와 동일한 형식)
-                      const Text(
-                        '- 부적절한 제목이나 이미지는 신고 대상이 될 수 있으며, 관련 책임은 등록 주체에게 있음을 알려드립니다.',
-                        style: TextStyle(fontSize: 14, color: Colors.grey),
-                      ),
-                      const SizedBox(height: 24),
-
-                      // 설명 입력 영역
-                      const Text(
-                        '설명',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      TextFormField(
-                        key: ValueKey<String>('desc_$itemId'),
-                        initialValue: itemData.description,
-                        maxLines: 4,
-                        style: const TextStyle(color: Colors.white),
-                        onChanged: (String val) {
-                          context.read<MemoryGallerySettingBloc>().add(
-                            UpdateMemoryItemDescription(itemId, val),
-                          );
-                        },
-                        decoration: InputDecoration(
-                          filled: true,
-                          fillColor: Colors.white.withValues(alpha: 0.07),
-                          hintText: '설명을 입력해주세요',
-                          hintStyle: const TextStyle(color: Colors.white38),
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide: BorderSide(
-                              color: isDescriptionValid
-                                  ? AppColors.neonPurple
-                                  : Colors.red,
-                              width: 1.5,
-                            ),
-                          ),
-                          enabledBorder: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide: BorderSide(
-                              color: isDescriptionValid
-                                  ? Colors.white24
-                                  : Colors.red,
-                              width: isDescriptionValid ? 1.0 : 1.5,
-                            ),
-                          ),
-                          focusedBorder: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide: BorderSide(
-                              color: isDescriptionValid
-                                  ? AppColors.neonPurple
-                                  : Colors.red,
-                              width: 1.5,
-                            ),
-                          ),
-                          errorText: !isDescriptionValid
-                              ? '설명은 최소 1글자 이상이어야 합니다.'
-                              : null,
-                        ),
-                      ),
-                      const SizedBox(height: 40),
-                    ],
-                  ),
-                ),
-              ),
-
-              // 하단 버튼 영역 (삭제 + 닫기)
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 32,
-                  vertical: 16,
-                ),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1A1A2E),
-                  border: Border(
-                    top: BorderSide(
-                      color: Colors.white.withValues(alpha: 0.1),
-                    ),
-                  ),
-                ),
-                child: Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: ElevatedButton(
-                        onPressed: () {
-                          Navigator.of(context).pop();
-                          context.read<MemoryGallerySettingBloc>().add(
-                            RemoveMemoryItem(itemId),
-                          );
-                        },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.transparent,
-                          foregroundColor: Colors.redAccent,
-                          padding: const EdgeInsets.symmetric(vertical: 16),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            side: const BorderSide(
-                              color: Colors.redAccent,
-                              width: 1.5,
-                            ),
-                          ),
-                          elevation: 0,
-                        ),
-                        child: const Text(
-                          '삭제',
-                          style: TextStyle(
-                            fontFamily: 'WantedSans',
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: ElevatedButton(
-                        onPressed: () => Navigator.of(context).pop(),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.neonPurple,
-                          foregroundColor: Colors.white,
-                          padding: const EdgeInsets.symmetric(vertical: 16),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          elevation: 0,
-                        ),
-                        child: const Text(
-                          '닫기',
-                          style: TextStyle(
-                            fontFamily: 'WantedSans',
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
 }

--- a/lib/features/addgift/presentation/views/memory_gallery_setting_view.dart
+++ b/lib/features/addgift/presentation/views/memory_gallery_setting_view.dart
@@ -1,19 +1,17 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gifo/features/addgift/model/gallery_item.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:reorderable_grid_view/reorderable_grid_view.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
-import '../widgets/memory_gallery/memory_desktop_card.dart';
 import '../widgets/memory_gallery/memory_edit_form.dart';
-import '../widgets/memory_gallery/memory_mobile_card.dart';
+import '../widgets/memory_gallery/memory_gallery_bottom_bar.dart';
+import '../widgets/memory_gallery/memory_gallery_desktop_body.dart';
+import '../widgets/memory_gallery/memory_gallery_mobile_body.dart';
 import '../widgets/step_indicator.dart';
 
 class MemoryGallerySettingView extends StatelessWidget {
@@ -22,7 +20,7 @@ class MemoryGallerySettingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // GiftPackagingBloc을 주입하여 MemoryGallerySettingBloc이 내부에서 갤러리 데이터를 동기화할 수 있게 합니다.
-    return BlocProvider(
+    return BlocProvider<MemoryGallerySettingBloc>(
       create: (BuildContext context) =>
           MemoryGallerySettingBloc(context.read<GiftPackagingBloc>()),
       child: const _MemoryGallerySettingContent(),
@@ -57,7 +55,9 @@ class _MemoryGallerySettingViewState
 
   // GiftPackagingBloc의 기존 gallery 데이터를 토대로 MemoryGallerySettingBloc을 초기화합니다.
   void _initBlocFromPackagingState() {
-    final GiftPackagingState packagingState = context.read<GiftPackagingBloc>().state;
+    final GiftPackagingState packagingState = context
+        .read<GiftPackagingBloc>()
+        .state;
     if (packagingState.gallery.isEmpty) return;
 
     final List<MemoryGalleryItemData> initialItems =
@@ -94,10 +94,24 @@ class _MemoryGallerySettingViewState
     }
   }
 
+  void _addMemoryItemAndScroll() {
+    context.read<MemoryGallerySettingBloc>().add(const AddMemoryItem());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
   // 모바일: BottomSheet / 데스크톱: 우측 슬라이드 패널
   void _showEditModal(BuildContext context, MemoryGalleryItemData itemData) {
     final bool isMobile = MediaQuery.sizeOf(context).width < 600;
-    final MemoryGallerySettingBloc memoryBloc = context.read<MemoryGallerySettingBloc>();
+    final MemoryGallerySettingBloc memoryBloc = context
+        .read<MemoryGallerySettingBloc>();
 
     memoryBloc.add(SelectMemoryItem(itemData.id));
 
@@ -109,13 +123,14 @@ class _MemoryGallerySettingViewState
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(24.0)),
         ),
-        builder: (BuildContext modalContext) => BlocProvider.value(
-          value: memoryBloc,
-          child: MemoryEditForm(
-            itemId: itemData.id,
-            onPickImage: () => _pickImage(itemData.id),
-          ),
-        ),
+        builder: (BuildContext modalContext) =>
+            BlocProvider<MemoryGallerySettingBloc>.value(
+              value: memoryBloc,
+              child: MemoryEditForm(
+                itemId: itemData.id,
+                onPickImage: () => _pickImage(itemData.id),
+              ),
+            ),
       ).then((_) {
         if (mounted) {
           memoryBloc.add(const ClearMemoryItemSelection());
@@ -142,7 +157,7 @@ class _MemoryGallerySettingViewState
                   child: SizedBox(
                     width: 480,
                     height: double.infinity,
-                    child: BlocProvider.value(
+                    child: BlocProvider<MemoryGallerySettingBloc>.value(
                       value: memoryBloc,
                       child: MemoryEditForm(
                         itemId: itemData.id,
@@ -236,7 +251,9 @@ class _MemoryGallerySettingViewState
               },
             ),
             // 데스크톱에서만 appbar에 진행도 표시
-            actions: <Widget>[if (!isMobile) const StepIndicator(activeStep: 2)],
+            actions: <Widget>[
+              if (!isMobile) const StepIndicator(activeStep: 2),
+            ],
           ),
           body: Stack(
             children: <Widget>[
@@ -245,595 +262,37 @@ class _MemoryGallerySettingViewState
               ),
               SafeArea(
                 child: isMobile
-                    ? _buildMobileBody(context, galleryState)
-                    : _buildDesktopBody(context, galleryState),
+                    ? MemoryGalleryMobileBody(
+                        galleryState: galleryState,
+                        scrollController: _scrollController,
+                        onAddItem: _addMemoryItemAndScroll,
+                        onItemTap: (MemoryGalleryItemData item) =>
+                            _showEditModal(context, item),
+                        isItemIncomplete: _isItemIncomplete,
+                      )
+                    : MemoryGalleryDesktopBody(
+                        galleryState: galleryState,
+                        scrollController: _scrollController,
+                        onAddItem: _addMemoryItemAndScroll,
+                        onItemTap: (MemoryGalleryItemData item) =>
+                            _showEditModal(context, item),
+                        isItemIncomplete: _isItemIncomplete,
+                      ),
               ),
             ],
           ),
-          bottomNavigationBar: _buildBottomBar(
-            context,
-            galleryState.uiItems.length,
-            canSave,
+          bottomNavigationBar: MemoryGalleryBottomBar(
+            itemCount: galleryState.uiItems.length,
+            canSave: canSave,
+            onComplete: () {
+              context.read<MemoryGallerySettingBloc>().add(
+                const SortMemoryItems(MemorySortType.manual),
+              );
+              context.push('/addgift/delivery-method');
+            },
           ),
         );
       },
     );
   }
-
-  Widget _buildSortButton(
-    BuildContext context,
-    MemoryGallerySettingState state,
-    MemorySortType type,
-    String label, {
-    bool isMobile = false,
-  }) {
-    final bool isSelected = state.sortType == type;
-
-    return InkWell(
-      onTap: () {
-        context.read<MemoryGallerySettingBloc>().add(SortMemoryItems(type));
-      },
-      borderRadius: BorderRadius.circular(20),
-      child: Container(
-        padding: EdgeInsets.symmetric(
-          horizontal: isMobile ? 8 : 12,
-          vertical: isMobile ? 6 : 8,
-        ),
-        decoration: BoxDecoration(
-          color: isSelected
-              ? AppColors.neonPurple.withValues(alpha: 0.2)
-              : Colors.white.withValues(alpha: 0.06),
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(
-            color: isSelected
-                ? AppColors.neonPurple
-                : Colors.white.withValues(alpha: 0.2),
-          ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Text(
-              label,
-              style: TextStyle(
-                fontFamily: 'WantedSans',
-                color: isSelected ? AppColors.neonPurple : Colors.white60,
-                fontSize: isMobile ? 12 : 14,
-                fontWeight: isSelected ? FontWeight.bold : FontWeight.w500,
-              ),
-            ),
-            if (isSelected) ...<Widget>[
-              const SizedBox(width: 4),
-              Icon(
-                state.isAscending ? Icons.arrow_upward : Icons.arrow_downward,
-                size: isMobile ? 14 : 16,
-                color: Colors.white,
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-
-  // ------------------------------------------------------------------
-  // 데스크톱 레이아웃: 헤더(초기화+추가 버튼) + ReorderableListView 세로 스크롤
-  // Wrap 기반 그리드는 ReorderableDragStartListener를 지원하지 않아 드래그가 작동하지 않습니다.
-  // ------------------------------------------------------------------
-  Widget _buildDesktopBody(
-    BuildContext context,
-    MemoryGallerySettingState galleryState,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 40.0, right: 40.0, top: 24.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          // 리스트 바로 위 헤더: 아이템 개수 + 추가/초기화 버튼
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: <Widget>[
-                  _buildSortButton(
-                    context,
-                    galleryState,
-                    MemorySortType.createdAt,
-                    '생성순',
-                  ),
-                  _buildSortButton(
-                    context,
-                    galleryState,
-                    MemorySortType.titleKo,
-                    '제목 (한글)',
-                  ),
-                  _buildSortButton(
-                    context,
-                    galleryState,
-                    MemorySortType.titleEn,
-                    '제목 (영어)',
-                  ),
-                ],
-              ),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  ElevatedButton.icon(
-                    onPressed: () {
-                      context.read<MemoryGallerySettingBloc>().add(
-                        const AddMemoryItem(),
-                      );
-                      WidgetsBinding.instance.addPostFrameCallback((_) {
-                        if (_scrollController.hasClients) {
-                          _scrollController.animateTo(
-                            _scrollController.position.maxScrollExtent,
-                            duration: const Duration(milliseconds: 300),
-                            curve: Curves.easeOut,
-                          );
-                        }
-                      });
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.neonBlue,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                    ),
-                    icon: const Icon(Icons.add, size: 18),
-                    label: const Text(
-                      '추가',
-                      style: TextStyle(fontFamily: 'PFStardust'),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  ElevatedButton.icon(
-                    onPressed: () {
-                      context.read<MemoryGallerySettingBloc>().add(
-                        const RemoveAllMemoryItems(),
-                      );
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.red.shade400,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                    ),
-                    icon: const Icon(Icons.delete_outline, size: 18),
-                    label: const Text(
-                      '초기화',
-                      style: TextStyle(fontFamily: 'PFStardust'),
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-          const SizedBox(height: 20),
-
-          // 반응형 그리드: 화면 너비에 따라 column 수 유동 조절
-          Expanded(
-            child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-                // 너비에 따라 열 수 자동 결정 (최소 카드 너비 기준 약 160px)
-                final double availableWidth = constraints.maxWidth;
-                int crossAxisCount;
-                if (availableWidth >= 1400) {
-                  crossAxisCount = 5;
-                } else if (availableWidth >= 1100) {
-                  crossAxisCount = 4;
-                } else if (availableWidth >= 800) {
-                  crossAxisCount = 3;
-                } else {
-                  crossAxisCount = 2;
-                }
-
-                return Theme(
-                  data: ThemeData(canvasColor: Colors.transparent),
-                  child: ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(context).copyWith(
-                      dragDevices: <PointerDeviceKind>{
-                        PointerDeviceKind.touch,
-                        PointerDeviceKind.mouse,
-                        PointerDeviceKind.trackpad,
-                      },
-                    ),
-                    child: Scrollbar(
-                      controller: _scrollController,
-                      thumbVisibility: true,
-                      child: ReorderableGridView.builder(
-                        controller: _scrollController,
-                        // 그리드 외곽 padding으로 아이템 잘림 방지
-                        padding: const EdgeInsets.fromLTRB(4, 4, 20, 16),
-                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: crossAxisCount,
-                          crossAxisSpacing: 24,
-                          mainAxisSpacing: 24,
-                          childAspectRatio: 0.7,
-                        ),
-                        itemCount: galleryState.uiItems.length + 1,
-                        onReorder: (int oldIndex, int newIndex) {
-                          // 마지막 요소(추가 카드)에 대한 드래그 이벤트 무시
-                          if (oldIndex == galleryState.uiItems.length ||
-                              newIndex == galleryState.uiItems.length) {
-                            return;
-                          }
-                          context.read<MemoryGallerySettingBloc>().add(
-                            ReorderMemoryItems(oldIndex, newIndex),
-                          );
-                        },
-                        itemBuilder: (BuildContext context, int index) {
-                          if (index == galleryState.uiItems.length) {
-                            return Container(
-                              key: const ValueKey<String>('add_card'),
-                              child: _buildDesktopAddCard(),
-                            );
-                          }
-                          final MemoryGalleryItemData item =
-                              galleryState.uiItems[index];
-                          return MemoryDesktopCard(
-                            key: ValueKey<int>(item.id),
-                            index: index,
-                            itemData: item,
-                            isIncomplete: _isItemIncomplete(item),
-                            isSelected: galleryState.selectedItemId == item.id,
-                            isHovered: galleryState.hoveredItemId == item.id,
-                            onTap: () => _showEditModal(context, item),
-                            onRemove: () {
-                              context.read<MemoryGallerySettingBloc>().add(
-                                RemoveMemoryItem(item.id),
-                              );
-                              context.read<MemoryGallerySettingBloc>().add(
-                                const ClearHoverMemoryItem(),
-                              );
-                            },
-                            onHoverEnter: () => context
-                                .read<MemoryGallerySettingBloc>()
-                                .add(HoverMemoryItem(item.id)),
-                            onHoverExit: () => context
-                                .read<MemoryGallerySettingBloc>()
-                                .add(const ClearHoverMemoryItem()),
-                          );
-                        },
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildDesktopAddCard() {
-    return OutlinedButton(
-      style: OutlinedButton.styleFrom(
-        backgroundColor: AppColors.neonPurple.withValues(alpha: 0.05),
-        side: BorderSide(
-          color: AppColors.neonPurple.withValues(alpha: 0.4),
-          width: 1.5,
-        ),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16.0),
-        ),
-        padding: const EdgeInsets.symmetric(vertical: 36.0),
-      ),
-      onPressed: () {
-        context.read<MemoryGallerySettingBloc>().add(const AddMemoryItem());
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (_scrollController.hasClients) {
-            _scrollController.animateTo(
-              _scrollController.position.maxScrollExtent,
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeOut,
-            );
-          }
-        });
-      },
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Icon(
-            Icons.add_circle_outline,
-            size: 28,
-            color: AppColors.neonPurple.withValues(alpha: 0.7),
-          ),
-          const SizedBox(width: 10),
-          Text(
-            '추억 추가하기',
-            style: TextStyle(
-              fontFamily: 'WantedSans',
-              color: AppColors.neonPurple.withValues(alpha: 0.8),
-              fontWeight: FontWeight.bold,
-              fontSize: 16,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  // ------------------------------------------------------------------
-  // 모바일 레이아웃: 기존 세로 스크롤 리스트 유지
-  // ------------------------------------------------------------------
-  Widget _buildMobileBody(
-    BuildContext context,
-    MemoryGallerySettingState galleryState,
-  ) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        // 헤더: 아이템 개수 + 추가/초기화 버튼
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-              Wrap(
-                spacing: 6,
-                runSpacing: 6,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: <Widget>[
-                  _buildSortButton(
-                    context,
-                    galleryState,
-                    MemorySortType.createdAt,
-                    '생성순',
-                    isMobile: true,
-                  ),
-                  _buildSortButton(
-                    context,
-                    galleryState,
-                    MemorySortType.titleKo,
-                    '제목 (한글)',
-                    isMobile: true,
-                  ),
-                  _buildSortButton(
-                    context,
-                    galleryState,
-                    MemorySortType.titleEn,
-                    '제목 (영어)',
-                    isMobile: true,
-                  ),
-                ],
-              ),
-              Row(
-                children: <Widget>[
-                  ElevatedButton.icon(
-                    onPressed: () {
-                      context.read<MemoryGallerySettingBloc>().add(
-                        const AddMemoryItem(),
-                      );
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.neonBlue,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                    ),
-                    icon: const Icon(Icons.add, size: 16),
-                    label: const Text(
-                      '추가',
-                      style: TextStyle(fontFamily: 'PFStardust'),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  ElevatedButton.icon(
-                    onPressed: () {
-                      context.read<MemoryGallerySettingBloc>().add(
-                        const RemoveAllMemoryItems(),
-                      );
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.red.shade400,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                    ),
-                    icon: const Icon(Icons.delete_outline, size: 16),
-                    label: const Text(
-                      '초기화',
-                      style: TextStyle(fontFamily: 'PFStardust'),
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 12),
-
-        // 리스트가 빈 경우: 중앙에 추가하기 버튼 안내
-        if (galleryState.uiItems.isEmpty)
-          Expanded(
-            child: Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  Icon(
-                    Icons.photo_library_outlined,
-                    size: 64,
-                    color: Colors.white24,
-                  ),
-                  const SizedBox(height: 16),
-                  const Text(
-                    '아직 등록된 추억이 없어요.',
-                    style: TextStyle(color: Colors.white38, fontSize: 15),
-                  ),
-                  const SizedBox(height: 20),
-                  ElevatedButton.icon(
-                    onPressed: () {
-                      context.read<MemoryGallerySettingBloc>().add(
-                        const AddMemoryItem(),
-                      );
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.neonBlue,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 24,
-                        vertical: 12,
-                      ),
-                    ),
-                    icon: const Icon(Icons.add),
-                    label: const Text(
-                      '추억 추가하기',
-                      style: TextStyle(fontFamily: 'PFStardust'),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          )
-        else
-          Expanded(
-            child: Theme(
-              data: ThemeData(canvasColor: Colors.transparent),
-              child: ScrollConfiguration(
-                behavior: ScrollConfiguration.of(context).copyWith(
-                  dragDevices: <PointerDeviceKind>{
-                    PointerDeviceKind.touch,
-                    PointerDeviceKind.mouse,
-                  },
-                ),
-                child: ReorderableListView.builder(
-                  scrollController: _scrollController,
-                  scrollDirection: Axis.vertical,
-                  padding: const EdgeInsets.only(
-                    left: 16.0,
-                    right: 16.0,
-                    top: 8.0,
-                  ),
-                  itemCount: galleryState.uiItems.length,
-                  buildDefaultDragHandles: false,
-                  onReorder: (int oldIndex, int newIndex) {
-                    context.read<MemoryGallerySettingBloc>().add(
-                      ReorderMemoryItems(oldIndex, newIndex),
-                    );
-                  },
-                  // 모바일에는 하단 추가 버튼 없이 헤더의 추가 버튼을 사용합니다.
-                  itemBuilder: (BuildContext context, int index) {
-                    final MemoryGalleryItemData item =
-                        galleryState.uiItems[index];
-                    return MemoryMobileCard(
-                      key: ValueKey<int>(item.id),
-                      index: index,
-                      itemData: item,
-                      isIncomplete: _isItemIncomplete(item),
-                      isSelected: galleryState.selectedItemId == item.id,
-                      onTap: () => _showEditModal(context, item),
-                      onRemove: () =>
-                          context.read<MemoryGallerySettingBloc>().add(
-                            RemoveMemoryItem(item.id),
-                          ),
-                    );
-                  },
-                ),
-              ),
-            ),
-          ),
-      ],
-    );
-  }
-
-  // 하단 진행 상태 및 완료 버튼 (BottomNavigationBar)
-  Widget _buildBottomBar(BuildContext context, int itemCount, bool canSave) {
-    return SafeArea(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 20.0),
-        decoration: BoxDecoration(
-          color: AppColors.darkBg,
-          border: Border(
-            top: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
-          ),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                const Icon(
-                  Icons.photo_library_rounded,
-                  size: 20,
-                  color: Colors.white70,
-                ),
-                const SizedBox(width: 6),
-                Text(
-                  '추억 목록 [ $itemCount개 ]',
-                  style: const TextStyle(
-                    fontFamily: 'WantedSans',
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                  ),
-                ),
-              ],
-            ),
-            const Spacer(),
-            // 저장 조건 안내 Tooltip
-            const Tooltip(
-              triggerMode: TooltipTriggerMode.tap,
-              showDuration: Duration(seconds: 5),
-              margin: EdgeInsets.symmetric(horizontal: 24),
-              padding: EdgeInsets.all(12),
-              textStyle: TextStyle(
-                color: Colors.white,
-                fontSize: 13,
-                height: 1.5,
-              ),
-              message:
-                  '⚠️ 저장 완료 조건\n'
-                  '• 추억 최소 1개 이상 등록\n'
-                  '• 각 추억에 제목, 이미지, 설명 모두 입력',
-              child: Padding(
-                padding: EdgeInsets.only(right: 8),
-                child: Icon(Icons.info_outline, size: 20, color: Colors.grey),
-              ),
-            ),
-            const SizedBox(width: 12),
-            ElevatedButton(
-              // 조건 미충족 시 버튼 비활성화
-              onPressed: canSave
-                  ? () {
-                      context.read<MemoryGallerySettingBloc>().add(
-                        const SortMemoryItems(MemorySortType.manual),
-                      );
-                      context.push('/addgift/delivery-method');
-                    }
-                  : null,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.neonPurple,
-                foregroundColor: Colors.white,
-                disabledBackgroundColor: Colors.white12,
-                disabledForegroundColor: Colors.white38,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 24.0,
-                  vertical: 18.0,
-                ),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12.0),
-                ),
-                elevation: 0,
-              ),
-              child: const Text(
-                '추억 저장 완료',
-                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
 }

--- a/lib/features/addgift/presentation/views/quiz_setting_view.dart
+++ b/lib/features/addgift/presentation/views/quiz_setting_view.dart
@@ -669,6 +669,7 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                     itemBuilder: (BuildContext context, int index) {
                       final QuizItemData item = quizState.uiItems[index];
                       return QuizListItem(
+                        key: ValueKey<String>(item.id),
                         item: item,
                         index: index,
                         onRemove: () => _removeItem(item.id),

--- a/lib/features/addgift/presentation/views/quiz_setting_view.dart
+++ b/lib/features/addgift/presentation/views/quiz_setting_view.dart
@@ -10,9 +10,12 @@ import '../../../../core/widgets/packaging_loading_overlay.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../application/quiz_setting/quiz_setting_bloc.dart';
 import '../../model/quiz_setting_models.dart';
+import '../widgets/quiz/quiz_complete_button.dart';
 import '../widgets/quiz/quiz_edit_form.dart';
-import '../widgets/quiz/quiz_list_item.dart';
+import '../widgets/quiz/quiz_items_section.dart';
+import '../widgets/quiz/quiz_mobile_bottom_bar.dart';
 import '../widgets/quiz/quiz_settings_panel.dart';
+import '../widgets/quiz/quiz_title_bar.dart';
 import '../widgets/step_indicator.dart';
 
 class QuizSettingView extends StatelessWidget {
@@ -418,7 +421,12 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                   surfaceTintColor: Colors.transparent,
                   elevation: 0,
                   iconTheme: const IconThemeData(color: Colors.white),
-                  title: isMobile ? null : _buildTitleBar(),
+                  title: isMobile
+                      ? null
+                      : QuizTitleBar(
+                          userNameController: _userNameController,
+                          subTitleController: _subTitleController,
+                        ),
                   actions: const <Widget>[StepIndicator(activeStep: 3)],
                 ),
                 body: Stack(
@@ -434,7 +442,10 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                                   padding: const EdgeInsets.all(24.0),
                                   child: SingleChildScrollView(
                                     scrollDirection: Axis.horizontal,
-                                    child: _buildTitleBar(),
+                                    child: QuizTitleBar(
+                                      userNameController: _userNameController,
+                                      subTitleController: _subTitleController,
+                                    ),
                                   ),
                                 ),
                                 Expanded(
@@ -442,9 +453,14 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                                     padding: const EdgeInsets.symmetric(
                                       horizontal: 24.0,
                                     ),
-                                    child: _buildItemsSection(
-                                      isMobile,
-                                      quizState,
+                                    child: QuizItemsSection(
+                                      isMobile: isMobile,
+                                      quizState: quizState,
+                                      onAddItem: _addItem,
+                                      onRemoveAllItems: _removeAllItems,
+                                      onReorder: _onReorder,
+                                      onRemoveItem: _removeItem,
+                                      onTapItem: _showEditModal,
                                     ),
                                   ),
                                 ),
@@ -457,9 +473,14 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                                   flex: 7,
                                   child: Padding(
                                     padding: const EdgeInsets.all(40.0),
-                                    child: _buildItemsSection(
-                                      isMobile,
-                                      quizState,
+                                    child: QuizItemsSection(
+                                      isMobile: isMobile,
+                                      quizState: quizState,
+                                      onAddItem: _addItem,
+                                      onRemoveAllItems: _removeAllItems,
+                                      onReorder: _onReorder,
+                                      onRemoveItem: _removeItem,
+                                      onTapItem: _showEditModal,
                                     ),
                                   ),
                                 ),
@@ -492,7 +513,10 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                                           ),
                                         ),
                                         const SizedBox(height: 24),
-                                        _buildCompleteButton(),
+                                        QuizCompleteButton(
+                                          enabled: !_isSubmitting,
+                                          onPressed: _completePackage,
+                                        ),
                                       ],
                                     ),
                                   ),
@@ -504,265 +528,17 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                     if (_isSubmitting) const PackagingLoadingOverlay(),
                   ],
                 ),
-                bottomNavigationBar: isMobile ? _buildMobileBottomBar() : null,
+                bottomNavigationBar: isMobile
+                    ? QuizMobileBottomBar(
+                        isSubmitting: _isSubmitting,
+                        onShowSettings: _showMobileSettingsModal,
+                        onComplete: _completePackage,
+                      )
+                    : null,
               ),
             ),
           );
         },
-      ),
-    );
-  }
-
-  Widget _buildTitleBar() {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: <Widget>[
-        SizedBox(
-          width: 100,
-          child: TextFormField(
-            controller: _userNameController,
-            decoration: InputDecoration(
-              hintText: '닉네임',
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                vertical: 8,
-                horizontal: 12,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.3),
-                  width: 1,
-                ),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.2),
-                  width: 1,
-                ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(
-                  color: AppColors.neonPurple,
-                  width: 1.5,
-                ),
-              ),
-            ),
-            style: const TextStyle(color: Colors.white),
-          ),
-        ),
-        const SizedBox(width: 8),
-        const Text('님의', style: TextStyle(fontSize: 16, color: Colors.white70)),
-        const SizedBox(width: 8),
-        SizedBox(
-          width: 120,
-          child: TextFormField(
-            controller: _subTitleController,
-            decoration: InputDecoration(
-              hintText: '서브 타이틀',
-              hintStyle: const TextStyle(color: Colors.white38),
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                vertical: 8,
-                horizontal: 12,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.3),
-                  width: 1,
-                ),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(
-                  color: Colors.white.withValues(alpha: 0.2),
-                  width: 1,
-                ),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: const BorderSide(
-                  color: AppColors.neonPurple,
-                  width: 1.5,
-                ),
-              ),
-            ),
-            style: const TextStyle(color: Colors.white),
-          ),
-        ),
-        const SizedBox(width: 8),
-        const Text(
-          '문제 맞추기',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildItemsSection(bool isMobile, QuizSettingState quizState) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: <Widget>[
-            ElevatedButton(
-              onPressed: _addItem,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.neonPurple,
-                foregroundColor: Colors.white,
-                elevation: 0,
-              ),
-              child: const Text('추가'),
-            ),
-            const SizedBox(width: 8),
-            ElevatedButton(
-              onPressed: _removeAllItems,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.redAccent,
-                foregroundColor: Colors.white,
-                elevation: 0,
-              ),
-              child: const Text('모두 제거'),
-            ),
-          ],
-        ),
-        const SizedBox(height: 24),
-        Expanded(
-          child: Container(
-            width: double.infinity,
-            decoration: BoxDecoration(
-              border: Border.all(
-                color: Colors.white.withValues(alpha: 0.15),
-                width: 1,
-              ),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: quizState.uiItems.isEmpty
-                ? const Center(
-                    child: Text(
-                      '추가 버튼을 눌러 문제를 생성해보세요.',
-                      style: TextStyle(color: Colors.white38),
-                    ),
-                  )
-                : ReorderableListView.builder(
-                    padding: const EdgeInsets.all(16),
-                    itemCount: quizState.uiItems.length,
-                    onReorder: _onReorder,
-                    buildDefaultDragHandles: false,
-                    proxyDecorator:
-                        (Widget child, int index, Animation<double> animation) {
-                          return Material(
-                            color: Colors.transparent,
-                            elevation: 0,
-                            child: child,
-                          );
-                        },
-                    itemBuilder: (BuildContext context, int index) {
-                      final QuizItemData item = quizState.uiItems[index];
-                      return QuizListItem(
-                        key: ValueKey<String>(item.id),
-                        item: item,
-                        index: index,
-                        onRemove: () => _removeItem(item.id),
-                        onTap: () => _showEditModal(item),
-                      );
-                    },
-                  ),
-          ),
-        ),
-        if (isMobile) const SizedBox(height: 24),
-      ],
-    );
-  }
-
-  Widget _buildCompleteButton() {
-    return SizedBox(
-      height: 60,
-      child: ElevatedButton(
-        onPressed: _isSubmitting ? null : _completePackage,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF6DE1F1),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-          elevation: 0,
-        ),
-        child: const Text(
-          '포장 완료',
-          style: TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildMobileBottomBar() {
-    return SafeArea(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-        decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.07),
-          border: const Border(top: BorderSide(color: Colors.white12)),
-        ),
-        child: Row(
-          children: <Widget>[
-            InkWell(
-              onTap: () {
-                _showMobileSettingsModal();
-              },
-              borderRadius: BorderRadius.circular(16),
-              child: Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.07),
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.15),
-                    width: 2,
-                  ),
-                ),
-                child: const Icon(Icons.settings, color: Colors.white60),
-              ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: SizedBox(
-                height: 56,
-                child: ElevatedButton(
-                  onPressed: _isSubmitting ? null : _completePackage,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF6DE1F1),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                    elevation: 0,
-                  ),
-                  child: const Text(
-                    '포장 완료',
-                    style: TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/features/addgift/presentation/views/quiz_setting_view.dart
+++ b/lib/features/addgift/presentation/views/quiz_setting_view.dart
@@ -7,41 +7,50 @@ import '../../../../core/constants/app_colors.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
 import '../../application/gift_packaging_bloc.dart';
-import '../../model/gift_content.dart';
-import '../../model/quiz_content.dart';
+import '../../application/quiz_setting/quiz_setting_bloc.dart';
 import '../../model/quiz_setting_models.dart';
 
-class QuizSettingView extends StatefulWidget {
+class QuizSettingView extends StatelessWidget {
   const QuizSettingView({super.key});
 
   @override
-  State<QuizSettingView> createState() => _QuizSettingViewState();
+  Widget build(BuildContext context) {
+    return BlocProvider<QuizSettingBloc>(
+      create: (BuildContext ctx) =>
+          QuizSettingBloc(ctx.read<GiftPackagingBloc>()),
+      child: const _QuizSettingContent(),
+    );
+  }
 }
 
-class _QuizSettingViewState extends State<QuizSettingView> {
+class _QuizSettingContent extends StatefulWidget {
+  const _QuizSettingContent();
+
+  @override
+  State<_QuizSettingContent> createState() => _QuizSettingContentState();
+}
+
+class _QuizSettingContentState extends State<_QuizSettingContent> {
   final TextEditingController _userNameController = TextEditingController();
   final TextEditingController _subTitleController = TextEditingController();
+  final TextEditingController _successRewardNameController =
+      TextEditingController();
+  final TextEditingController _failRewardNameController =
+      TextEditingController();
 
-  final List<QuizItemData> _items = <QuizItemData>[];
-
-  // 보상 관련 상태
-  final QuizRewardData _successReward = QuizRewardData(requiredCount: 1);
-  final QuizRewardData _failReward = QuizRewardData();
-
-  String _selectedBgm = '신나는 생일';
   bool _isSubmitting = false;
+  final ImagePicker _picker = ImagePicker();
 
   @override
   void initState() {
     super.initState();
-    final GiftPackagingState blocState = context.read<GiftPackagingBloc>().state;
-    // BLoC에 기존 입력된 받는 분 정보가 있다면 불러오기
-    if (blocState.receiverName.isNotEmpty) {
-      _userNameController.text = blocState.receiverName;
+    final GiftPackagingState packagingState =
+        context.read<GiftPackagingBloc>().state;
+    if (packagingState.receiverName.isNotEmpty) {
+      _userNameController.text = packagingState.receiverName;
     }
-    // 초기 생성된 랜덤 타이틀을 서브타이틀 필드에 세팅
-    if (blocState.subTitle.isNotEmpty) {
-      _subTitleController.text = blocState.subTitle;
+    if (packagingState.subTitle.isNotEmpty) {
+      _subTitleController.text = packagingState.subTitle;
     }
 
     _userNameController.addListener(() {
@@ -49,10 +58,32 @@ class _QuizSettingViewState extends State<QuizSettingView> {
         SetReceiverName(_userNameController.text),
       );
     });
-    // 서브타이틀 리스너 추가
     _subTitleController.addListener(() {
       context.read<GiftPackagingBloc>().add(
         SetSubTitle(_subTitleController.text),
+      );
+    });
+    _successRewardNameController.addListener(() {
+      final QuizSettingState s = context.read<QuizSettingBloc>().state;
+      context.read<QuizSettingBloc>().add(
+        UpdateSuccessReward(
+          QuizRewardData(
+            requiredCount: s.successReward.requiredCount,
+            itemName: _successRewardNameController.text,
+            imageFile: s.successReward.imageFile,
+          ),
+        ),
+      );
+    });
+    _failRewardNameController.addListener(() {
+      final QuizSettingState s = context.read<QuizSettingBloc>().state;
+      context.read<QuizSettingBloc>().add(
+        UpdateFailReward(
+          QuizRewardData(
+            itemName: _failRewardNameController.text,
+            imageFile: s.failReward.imageFile,
+          ),
+        ),
       );
     });
   }
@@ -61,6 +92,8 @@ class _QuizSettingViewState extends State<QuizSettingView> {
   void dispose() {
     _userNameController.dispose();
     _subTitleController.dispose();
+    _successRewardNameController.dispose();
+    _failRewardNameController.dispose();
     super.dispose();
   }
 
@@ -71,36 +104,84 @@ class _QuizSettingViewState extends State<QuizSettingView> {
   }
 
   void _removeAllItems() {
-    setState(() {
-      _items.clear();
-      // 성공 기준 값도 문제가 없어지면 초기화하는 것이 좋을 수 있음
-      _successReward.requiredCount = 1;
-    });
+    final QuizSettingState s = context.read<QuizSettingBloc>().state;
+    context.read<QuizSettingBloc>().add(UpdateQuizItems(<QuizItemData>[]));
+    context.read<QuizSettingBloc>().add(
+      UpdateSuccessReward(
+        QuizRewardData(
+          requiredCount: 1,
+          itemName: s.successReward.itemName,
+          imageFile: s.successReward.imageFile,
+        ),
+      ),
+    );
+  }
+
+  void _removeItem(String itemId) {
+    final QuizSettingState s = context.read<QuizSettingBloc>().state;
+    final List<QuizItemData> updated =
+        s.uiItems.where((QuizItemData e) => e.id != itemId).toList();
+    context.read<QuizSettingBloc>().add(UpdateQuizItems(updated));
+    final int currentCount = s.successReward.requiredCount ?? 1;
+    if (updated.isEmpty) {
+      context.read<QuizSettingBloc>().add(
+        UpdateSuccessReward(
+          QuizRewardData(
+            requiredCount: 1,
+            itemName: s.successReward.itemName,
+            imageFile: s.successReward.imageFile,
+          ),
+        ),
+      );
+    } else if (currentCount > updated.length) {
+      context.read<QuizSettingBloc>().add(
+        UpdateSuccessReward(
+          QuizRewardData(
+            requiredCount: updated.length,
+            itemName: s.successReward.itemName,
+            imageFile: s.successReward.imageFile,
+          ),
+        ),
+      );
+    }
   }
 
   void _onReorder(int oldIndex, int newIndex) {
-    setState(() {
-      if (newIndex > oldIndex) {
-        newIndex -= 1;
-      }
-      final QuizItemData item = _items.removeAt(oldIndex);
-      _items.insert(newIndex, item);
-    });
+    final List<QuizItemData> items =
+        List<QuizItemData>.from(context.read<QuizSettingBloc>().state.uiItems);
+    if (newIndex > oldIndex) {
+      newIndex -= 1;
+    }
+    final QuizItemData item = items.removeAt(oldIndex);
+    items.insert(newIndex, item);
+    context.read<QuizSettingBloc>().add(UpdateQuizItems(items));
   }
 
   // --- [이미지 픽커 유틸] ---
 
   Future<void> _pickImageForReward(bool isSuccessReward) async {
-    final ImagePicker picker = ImagePicker();
-    final XFile? image = await picker.pickImage(source: ImageSource.gallery);
-    if (image != null) {
-      setState(() {
-        if (isSuccessReward) {
-          _successReward.imageFile = image;
-        } else {
-          _failReward.imageFile = image;
-        }
-      });
+    final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
+    if (!mounted || image == null) return;
+    final QuizSettingState s = context.read<QuizSettingBloc>().state;
+    if (isSuccessReward) {
+      context.read<QuizSettingBloc>().add(
+        UpdateSuccessReward(
+          QuizRewardData(
+            requiredCount: s.successReward.requiredCount,
+            itemName: s.successReward.itemName,
+            imageFile: image,
+          ),
+        ),
+      );
+    } else {
+      context.read<QuizSettingBloc>().add(
+        UpdateFailReward(
+          QuizRewardData(
+            itemName: s.failReward.itemName,
+            imageFile: image,
+          ),
+        ),
+      );
     }
   }
 
@@ -162,7 +243,6 @@ class _QuizSettingViewState extends State<QuizSettingView> {
   }
 
   void _showEditModal(QuizItemData item, {bool isNew = false}) {
-    // 깊은 복사본을 만들어 에디터에서 사용
     final QuizItemData editingItem = QuizItemData(
       id: item.id,
       type: item.type,
@@ -182,22 +262,22 @@ class _QuizSettingViewState extends State<QuizSettingView> {
       item: editingItem,
       isDesktop: !isMobile,
       onSave: (QuizItemData updatedItem) {
-        setState(() {
-          if (isNew) {
-            _items.add(updatedItem);
-            if (_items.isNotEmpty &&
-                _successReward.requiredCount! < _items.length) {
-              // _successReward.requiredCount = _items.length;
-            }
-          } else {
-            final int index = _items.indexWhere(
-              (QuizItemData e) => e.id == updatedItem.id,
-            );
-            if (index != -1) {
-              _items[index] = updatedItem;
-            }
+        final List<QuizItemData> current =
+            context.read<QuizSettingBloc>().state.uiItems;
+        if (isNew) {
+          context.read<QuizSettingBloc>().add(
+            UpdateQuizItems(<QuizItemData>[...current, updatedItem]),
+          );
+        } else {
+          final int index =
+              current.indexWhere((QuizItemData e) => e.id == updatedItem.id);
+          if (index != -1) {
+            final List<QuizItemData> updated =
+                List<QuizItemData>.from(current);
+            updated[index] = updatedItem;
+            context.read<QuizSettingBloc>().add(UpdateQuizItems(updated));
           }
-        });
+        }
         Navigator.pop(context);
       },
     );
@@ -225,43 +305,54 @@ class _QuizSettingViewState extends State<QuizSettingView> {
         barrierLabel: 'Dismiss',
         barrierColor: Colors.black54,
         transitionDuration: const Duration(milliseconds: 300),
-        pageBuilder:
-            (
-              BuildContext context,
-              Animation<double> animation,
-              Animation<double> secondaryAnimation,
-            ) {
-              return SafeArea(
-                child: Align(
-                  alignment: Alignment.centerRight,
-                  child: Material(
-                    color: Colors.transparent,
-                    child: SizedBox(
-                      width: 500,
-                      height: double.infinity,
-                      child: form,
-                    ),
-                  ),
+        pageBuilder: (
+          BuildContext context,
+          Animation<double> animation,
+          Animation<double> secondaryAnimation,
+        ) {
+          return SafeArea(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: Material(
+                color: Colors.transparent,
+                child: SizedBox(
+                  width: 500,
+                  height: double.infinity,
+                  child: form,
                 ),
-              );
-            },
-        transitionBuilder:
-            (
-              BuildContext context,
-              Animation<double> animation,
-              Animation<double> secondaryAnimation,
-              Widget child,
-            ) {
-              return SlideTransition(
-                position: Tween<Offset>(
-                  begin: const Offset(1, 0),
-                  end: Offset.zero,
-                ).animate(animation),
-                child: child,
-              );
-            },
+              ),
+            ),
+          );
+        },
+        transitionBuilder: (
+          BuildContext context,
+          Animation<double> animation,
+          Animation<double> secondaryAnimation,
+          Widget child,
+        ) {
+          return SlideTransition(
+            position: Tween<Offset>(
+              begin: const Offset(1, 0),
+              end: Offset.zero,
+            ).animate(animation),
+            child: child,
+          );
+        },
       );
     }
+  }
+
+  // --- [포장 완료] ---
+
+  void _completePackage() {
+    final GiftPackagingBloc packagingBloc = context.read<GiftPackagingBloc>();
+    context.read<QuizSettingBloc>().add(
+      SubmitQuizSetting(
+        receiverName: _userNameController.text.trim(),
+        subTitle: _subTitleController.text.trim(),
+        gallery: packagingBloc.state.gallery,
+      ),
+    );
   }
 
   // --- [빌더] ---
@@ -289,83 +380,102 @@ class _QuizSettingViewState extends State<QuizSettingView> {
           setState(() => _isSubmitting = true);
         }
       },
-      child: Title(
-      title: '선물 포장하기 - Gifo',
-      color: AppColors.darkBg,
-      child: Scaffold(
-        backgroundColor: AppColors.darkBg,
-        appBar: AppBar(
-        toolbarHeight: 68,
-        backgroundColor: AppColors.darkBg,
-        surfaceTintColor: Colors.transparent,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.white),
-        title: isMobile ? null : _buildTitleBar(),
-        actions: <Widget>[_buildStepIndicator()],
-      ),
-      body: Stack(
-        children: <Widget>[
-          Positioned.fill(
-            child: CustomPaint(painter: GridBackgroundPainter()),
-          ),
-          SafeArea(
-            child: isMobile
-                ? Column(
-                    children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.all(24.0),
-                        child: SingleChildScrollView(
-                          scrollDirection: Axis.horizontal,
-                          child: _buildTitleBar(),
-                        ),
-                      ),
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                          child: _buildItemsSection(isMobile),
-                        ),
-                      ),
-                    ],
-                  )
-                : Row(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      Expanded(
-                        flex: 7,
-                        child: Padding(
-                          padding: const EdgeInsets.all(40.0),
-                          child: _buildItemsSection(isMobile),
-                        ),
-                      ),
-                      Container(
-                        width: 1,
-                        color: Colors.white.withValues(alpha: 0.1),
-                      ),
-                      Expanded(
-                        flex: 3,
-                        child: Padding(
-                          padding: const EdgeInsets.all(40.0),
-                          child: Column(
+      child: BlocBuilder<QuizSettingBloc, QuizSettingState>(
+        builder: (BuildContext context, QuizSettingState quizState) {
+          return Title(
+            title: '선물 포장하기 - Gifo',
+            color: AppColors.darkBg,
+            child: Scaffold(
+              backgroundColor: AppColors.darkBg,
+              appBar: AppBar(
+                toolbarHeight: 68,
+                backgroundColor: AppColors.darkBg,
+                surfaceTintColor: Colors.transparent,
+                elevation: 0,
+                iconTheme: const IconThemeData(color: Colors.white),
+                title: isMobile ? null : _buildTitleBar(),
+                actions: <Widget>[_buildStepIndicator()],
+              ),
+              body: Stack(
+                children: <Widget>[
+                  Positioned.fill(
+                    child: CustomPaint(painter: GridBackgroundPainter()),
+                  ),
+                  SafeArea(
+                    child: isMobile
+                        ? Column(
+                            children: <Widget>[
+                              Padding(
+                                padding: const EdgeInsets.all(24.0),
+                                child: SingleChildScrollView(
+                                  scrollDirection: Axis.horizontal,
+                                  child: _buildTitleBar(),
+                                ),
+                              ),
+                              Expanded(
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 24.0,
+                                  ),
+                                  child: _buildItemsSection(
+                                    isMobile,
+                                    quizState,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          )
+                        : Row(
                             crossAxisAlignment: CrossAxisAlignment.stretch,
                             children: <Widget>[
                               Expanded(
-                                child: SingleChildScrollView(
-                                  child: _buildSettingsSection(isMobile: false),
+                                flex: 7,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(40.0),
+                                  child: _buildItemsSection(
+                                    isMobile,
+                                    quizState,
+                                  ),
                                 ),
                               ),
-                          const SizedBox(height: 24),
-                          _buildCompleteButton(),
-                        ],
-                      ),
-                    ),
+                              Container(
+                                width: 1,
+                                color: Colors.white.withValues(alpha: 0.1),
+                              ),
+                              Expanded(
+                                flex: 3,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(40.0),
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    children: <Widget>[
+                                      Expanded(
+                                        child: SingleChildScrollView(
+                                          child: _buildSettingsSection(
+                                            quizState,
+                                            isMobile: false,
+                                          ),
+                                        ),
+                                      ),
+                                      const SizedBox(height: 24),
+                                      _buildCompleteButton(),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
                   ),
                 ],
               ),
-          ),
-        ],
+              bottomNavigationBar:
+                  isMobile ? _buildMobileBottomBar() : null,
+            ),
+          );
+        },
       ),
-      bottomNavigationBar: isMobile ? _buildMobileBottomBar() : null,
-    )));
+    );
   }
 
   Widget _buildStepIndicator() {
@@ -514,7 +624,7 @@ class _QuizSettingViewState extends State<QuizSettingView> {
     );
   }
 
-  Widget _buildItemsSection(bool isMobile) {
+  Widget _buildItemsSection(bool isMobile, QuizSettingState quizState) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -553,7 +663,7 @@ class _QuizSettingViewState extends State<QuizSettingView> {
               ),
               borderRadius: BorderRadius.circular(12),
             ),
-            child: _items.isEmpty
+            child: quizState.uiItems.isEmpty
                 ? const Center(
                     child: Text(
                       '추가 버튼을 눌러 문제를 생성해보세요.',
@@ -562,19 +672,22 @@ class _QuizSettingViewState extends State<QuizSettingView> {
                   )
                 : ReorderableListView.builder(
                     padding: const EdgeInsets.all(16),
-                    itemCount: _items.length,
+                    itemCount: quizState.uiItems.length,
                     onReorder: _onReorder,
                     buildDefaultDragHandles: false,
-                    proxyDecorator:
-                        (Widget child, int index, Animation<double> animation) {
-                          return Material(
-                            color: Colors.transparent,
-                            elevation: 0,
-                            child: child,
-                          );
-                        },
+                    proxyDecorator: (
+                      Widget child,
+                      int index,
+                      Animation<double> animation,
+                    ) {
+                      return Material(
+                        color: Colors.transparent,
+                        elevation: 0,
+                        child: child,
+                      );
+                    },
                     itemBuilder: (BuildContext context, int index) {
-                      final QuizItemData item = _items[index];
+                      final QuizItemData item = quizState.uiItems[index];
                       return _buildQuizListItem(item, index);
                     },
                   ),
@@ -643,23 +756,17 @@ class _QuizSettingViewState extends State<QuizSettingView> {
         ),
         trailing: IconButton(
           icon: const Icon(Icons.close, size: 24, color: Colors.red),
-          onPressed: () {
-            setState(() {
-              _items.removeWhere((QuizItemData e) => e.id == item.id);
-              if (_items.isEmpty) {
-                _successReward.requiredCount = 1;
-              } else if (_successReward.requiredCount! > _items.length) {
-                _successReward.requiredCount = _items.length;
-              }
-            });
-          },
+          onPressed: () => _removeItem(item.id),
         ),
         onTap: () => _showEditModal(item),
       ),
     );
   }
 
-  Widget _buildSettingsSection({required bool isMobile}) {
+  Widget _buildSettingsSection(
+    QuizSettingState quizState, {
+    required bool isMobile,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
@@ -679,48 +786,70 @@ class _QuizSettingViewState extends State<QuizSettingView> {
                 children: <Widget>[
                   const Text(
                     '맞춘 문제가 ',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white),
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
                   ),
                   DropdownButtonHideUnderline(
                     child: DropdownButton<int>(
-                      value: _items.isEmpty
+                      value: quizState.uiItems.isEmpty
                           ? 1
-                          : (_successReward.requiredCount! > _items.length
-                                ? _items.length
-                                : _successReward.requiredCount),
+                          : (quizState.successReward.requiredCount! >
+                                    quizState.uiItems.length
+                                ? quizState.uiItems.length
+                                : quizState.successReward.requiredCount),
                       alignment: Alignment.center,
                       style: const TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                         color: Colors.white,
                       ),
-                      icon: const Icon(Icons.keyboard_arrow_down, size: 20, color: Colors.white38),
-                      items:
-                          List<int>.generate(
-                                _items.isEmpty ? 1 : _items.length,
-                                (int index) => index + 1,
-                              )
-                              .map(
-                                (int value) => DropdownMenuItem<int>(
-                                  value: value,
-                                  child: Text('$value개'),
-                                ),
-                              )
-                              .toList(),
-                      onChanged: _items.isEmpty
+                      icon: const Icon(
+                        Icons.keyboard_arrow_down,
+                        size: 20,
+                        color: Colors.white38,
+                      ),
+                      items: List<int>.generate(
+                            quizState.uiItems.isEmpty
+                                ? 1
+                                : quizState.uiItems.length,
+                            (int index) => index + 1,
+                          )
+                          .map(
+                            (int value) => DropdownMenuItem<int>(
+                              value: value,
+                              child: Text('$value개'),
+                            ),
+                          )
+                          .toList(),
+                      onChanged: quizState.uiItems.isEmpty
                           ? null
                           : (int? newVal) {
                               if (newVal != null) {
-                                setState(() {
-                                  _successReward.requiredCount = newVal;
-                                });
+                                context.read<QuizSettingBloc>().add(
+                                  UpdateSuccessReward(
+                                    QuizRewardData(
+                                      requiredCount: newVal,
+                                      itemName:
+                                          quizState.successReward.itemName,
+                                      imageFile:
+                                          quizState.successReward.imageFile,
+                                    ),
+                                  ),
+                                );
                               }
                             },
                     ),
                   ),
                   const Text(
                     ' 일 때',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white),
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
                   ),
                 ],
               ),
@@ -728,9 +857,9 @@ class _QuizSettingViewState extends State<QuizSettingView> {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
-                  _buildRewardImagePicker(true, _successReward),
+                  _buildRewardImagePicker(true, quizState),
                   const SizedBox(height: 16),
-                  _buildRewardNameInput(true, _successReward),
+                  _buildRewardNameInput(isSuccess: true),
                 ],
               ),
             ],
@@ -748,15 +877,19 @@ class _QuizSettingViewState extends State<QuizSettingView> {
             children: <Widget>[
               const Text(
                 '그 외 (실패 보상 등)',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white),
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
               ),
               const SizedBox(height: 16),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
-                  _buildRewardImagePicker(false, _failReward),
+                  _buildRewardImagePicker(false, quizState),
                   const SizedBox(height: 16),
-                  _buildRewardNameInput(false, _failReward),
+                  _buildRewardNameInput(isSuccess: false),
                 ],
               ),
             ],
@@ -765,13 +898,20 @@ class _QuizSettingViewState extends State<QuizSettingView> {
         const SizedBox(height: 40),
         const Text(
           'BGM 설정',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
         ),
         const SizedBox(height: 8),
         Container(
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
-            border: Border.all(color: Colors.white.withValues(alpha: 0.12), width: 1),
+            border: Border.all(
+              color: Colors.white.withValues(alpha: 0.12),
+              width: 1,
+            ),
             borderRadius: BorderRadius.circular(16),
           ),
           child: Column(
@@ -793,15 +933,17 @@ class _QuizSettingViewState extends State<QuizSettingView> {
                       ),
                       child: DropdownButtonHideUnderline(
                         child: DropdownButton<String>(
-                          value: _selectedBgm,
+                          value: quizState.selectedBgm,
                           isExpanded: true,
                           dropdownColor: const Color(0xFF1A1A1A),
                           style: const TextStyle(color: Colors.white),
                           iconEnabledColor: Colors.white38,
                           onChanged: (String? val) {
-                            setState(() {
-                              _selectedBgm = val!;
-                            });
+                            if (val != null) {
+                              context.read<QuizSettingBloc>().add(
+                                UpdateQuizBgm(val),
+                              );
+                            }
                           },
                           items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
                               .map(
@@ -843,7 +985,7 @@ class _QuizSettingViewState extends State<QuizSettingView> {
       child: ElevatedButton(
         onPressed: _isSubmitting ? null : _completePackage,
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF6DE1F1), // 하늘색 톤
+          backgroundColor: const Color(0xFF6DE1F1),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
           ),
@@ -861,7 +1003,10 @@ class _QuizSettingViewState extends State<QuizSettingView> {
     );
   }
 
-  Widget _buildRewardImagePicker(bool isSuccess, QuizRewardData reward) {
+  Widget _buildRewardImagePicker(bool isSuccess, QuizSettingState quizState) {
+    final XFile? imageFile = isSuccess
+        ? quizState.successReward.imageFile
+        : quizState.failReward.imageFile;
     return InkWell(
       onTap: () => _pickImageForReward(isSuccess),
       child: Container(
@@ -869,14 +1014,14 @@ class _QuizSettingViewState extends State<QuizSettingView> {
         decoration: BoxDecoration(
           color: Colors.white12,
           borderRadius: BorderRadius.circular(8),
-          image: reward.imageFile != null
+          image: imageFile != null
               ? DecorationImage(
-                  image: NetworkImage(reward.imageFile!.path),
+                  image: NetworkImage(imageFile.path),
                   fit: BoxFit.cover,
                 )
               : null,
         ),
-        child: reward.imageFile == null
+        child: imageFile == null
             ? const Center(
                 child: Text(
                   '물품 사진',
@@ -891,9 +1036,11 @@ class _QuizSettingViewState extends State<QuizSettingView> {
     );
   }
 
-  Widget _buildRewardNameInput(bool isSuccess, QuizRewardData reward) {
+  Widget _buildRewardNameInput({required bool isSuccess}) {
     return TextFormField(
-      initialValue: reward.itemName,
+      controller: isSuccess
+          ? _successRewardNameController
+          : _failRewardNameController,
       decoration: InputDecoration(
         hintText: '물품 이름',
         filled: true,
@@ -903,11 +1050,7 @@ class _QuizSettingViewState extends State<QuizSettingView> {
           borderSide: BorderSide.none,
         ),
       ),
-      onChanged: (String val) {
-        setState(() {
-          reward.itemName = val;
-        });
-      },
+      style: const TextStyle(color: Colors.white),
     );
   }
 
@@ -923,7 +1066,7 @@ class _QuizSettingViewState extends State<QuizSettingView> {
           children: <Widget>[
             InkWell(
               onTap: () {
-                _showMobileSettingsModal(context);
+                _showMobileSettingsModal();
               },
               borderRadius: BorderRadius.circular(16),
               child: Container(
@@ -932,9 +1075,12 @@ class _QuizSettingViewState extends State<QuizSettingView> {
                 decoration: BoxDecoration(
                   color: Colors.white.withValues(alpha: 0.07),
                   borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: Colors.white.withValues(alpha: 0.15), width: 2),
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    width: 2,
+                  ),
                 ),
-                child: Icon(Icons.settings, color: Colors.white60),
+                child: const Icon(Icons.settings, color: Colors.white60),
               ),
             ),
             const SizedBox(width: 16),
@@ -967,157 +1113,86 @@ class _QuizSettingViewState extends State<QuizSettingView> {
     );
   }
 
-  void _showMobileSettingsModal(BuildContext context) {
+  void _showMobileSettingsModal() {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (BuildContext context) {
-        return StatefulBuilder(
-          builder: (BuildContext context, StateSetter modalSetState) {
-            return SafeArea(
-              child: Container(
-                padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom,
-                ),
-                decoration: BoxDecoration(
-                  color: AppColors.darkBg,
-                  borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-                ),
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.all(24.0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      Container(
-                        width: 40,
-                        height: 4,
-                        margin: const EdgeInsets.only(bottom: 24),
-                        decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.15),
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                      const Text(
-                        '세팅',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-                      _buildSettingsSection(isMobile: true),
-                      const SizedBox(height: 16),
-                      SizedBox(
-                        width: double.infinity,
-                        child: ElevatedButton(
-                          onPressed: () {
-                            Navigator.pop(context);
-                            setState(() {});
-                          },
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: AppColors.neonPurple,
-                            foregroundColor: Colors.white,
-                            padding: const EdgeInsets.symmetric(vertical: 16),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            elevation: 0,
-                          ),
-                          child: const Text(
-                            '닫기',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                            ),
+      builder: (BuildContext modalContext) {
+        return BlocProvider<QuizSettingBloc>.value(
+          value: context.read<QuizSettingBloc>(),
+          child: BlocBuilder<QuizSettingBloc, QuizSettingState>(
+            builder: (BuildContext innerCtx, QuizSettingState quizState) {
+              return SafeArea(
+                child: Container(
+                  padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(innerCtx).viewInsets.bottom,
+                  ),
+                  decoration: BoxDecoration(
+                    color: AppColors.darkBg,
+                    borderRadius: const BorderRadius.vertical(
+                      top: Radius.circular(24),
+                    ),
+                  ),
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(24.0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Container(
+                          width: 40,
+                          height: 4,
+                          margin: const EdgeInsets.only(bottom: 24),
+                          decoration: BoxDecoration(
+                            color: Colors.white.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(2),
                           ),
                         ),
-                      ),
-                    ],
+                        const Text(
+                          '세팅',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        _buildSettingsSection(quizState, isMobile: true),
+                        const SizedBox(height: 16),
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            onPressed: () {
+                              Navigator.pop(innerCtx);
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.neonPurple,
+                              foregroundColor: Colors.white,
+                              padding: const EdgeInsets.symmetric(vertical: 16),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              elevation: 0,
+                            ),
+                            child: const Text(
+                              '닫기',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         );
       },
     );
-  }
-
-  void _completePackage() {
-    final GiftPackagingBloc bloc = context.read<GiftPackagingBloc>();
-
-    // 서브타이틀, BGM 저장
-    bloc.add(SetSubTitle(_subTitleController.text.trim()));
-    bloc.add(SetBgm(_selectedBgm));
-
-    // 로컬 QuizItemData -> freezed QuizItemModel 변환
-    final List<QuizItemModel> quizItems = _items.asMap().entries.map((
-      MapEntry<int, QuizItemData> entry,
-    ) {
-      final QuizItemData item = entry.value;
-      // 퀸즈 타입 문자열 변환
-      String typeStr;
-      switch (item.type) {
-        case QuizType.multipleChoice:
-          typeStr = 'multiple_choice';
-        case QuizType.ox:
-          typeStr = 'ox';
-        case QuizType.subjective:
-          typeStr = 'subjective';
-      }
-
-      // 객관식의 경우 인덱스 기반 answer를 실제 텍스트로 변환
-      List<String> answerTexts = item.answer;
-      if (item.type == QuizType.multipleChoice) {
-        answerTexts = item.answer.map((String idxStr) {
-          final int? idx = int.tryParse(idxStr);
-          if (idx != null && idx < item.options.length) {
-            return item.options[idx];
-          }
-          return idxStr;
-        }).toList();
-      }
-
-      return QuizItemModel(
-        quizId: entry.key + 1,
-        type: typeStr,
-        title: item.title,
-        imageUrl: item.imageFile?.path,
-        description: item.description.isEmpty ? null : item.description,
-        hint: item.hint.isEmpty ? null : item.hint,
-        options: item.options,
-        answer: answerTexts,
-        playLimit: item.playLimit,
-      );
-    }).toList();
-
-    final QuizContent quizContent = QuizContent(
-      successReward: QuizSuccessReward(
-        requiredCount: _successReward.requiredCount ?? 1,
-        itemName: _successReward.itemName,
-        imageUrl: _successReward.imageFile?.path ?? '',
-      ),
-      failReward: QuizFailReward(
-        itemName: _failReward.itemName,
-        imageUrl: _failReward.imageFile?.path ?? '',
-      ),
-      list: quizItems,
-    );
-
-    bloc.add(SetQuizContent(quizContent));
-    // 모든 데이터를 SubmitPackage 이벤트에 직접 담아 전달
-    bloc.add(
-      SubmitPackage(
-        receiverName: _userNameController.text.trim(),
-        subTitle: _subTitleController.text.trim(),
-        bgm: _selectedBgm,
-        gallery: bloc.state.gallery,
-        content: GiftContent(quiz: quizContent),
-      ),
-    );
-
   }
 }
 
@@ -1302,7 +1377,9 @@ class _QuizEditFormState extends State<_QuizEditForm> {
                       decoration: BoxDecoration(
                         color: Colors.white12,
                         borderRadius: BorderRadius.circular(12),
-                        border: Border.all(color: Colors.white.withValues(alpha: 0.15)),
+                        border: Border.all(
+                          color: Colors.white.withValues(alpha: 0.15),
+                        ),
                         image: _editingItem.imageFile != null
                             ? DecorationImage(
                                 image: NetworkImage(
@@ -1408,8 +1485,8 @@ class _QuizEditFormState extends State<_QuizEditForm> {
                       children: List<Widget>.generate(
                         _optionControllers.length,
                         (int index) {
-                          final bool isSelected = _selectedMultipleChoiceAnswers
-                              .contains(index);
+                          final bool isSelected =
+                              _selectedMultipleChoiceAnswers.contains(index);
                           return ChoiceChip(
                             label: Text('${index + 1}번'),
                             selected: isSelected,
@@ -1424,10 +1501,12 @@ class _QuizEditFormState extends State<_QuizEditForm> {
                             },
                             selectedColor: AppColors.neonPurple,
                             labelStyle: TextStyle(
-                              color: isSelected ? Colors.white : Colors.white38,
+                              color:
+                                  isSelected ? Colors.white : Colors.white38,
                               fontWeight: FontWeight.bold,
                             ),
-                            backgroundColor: Colors.white.withValues(alpha: 0.07),
+                            backgroundColor:
+                                Colors.white.withValues(alpha: 0.07),
                           );
                         },
                       ),
@@ -1479,12 +1558,14 @@ class _QuizEditFormState extends State<_QuizEditForm> {
                         Expanded(
                           child: OutlinedButton(
                             style: OutlinedButton.styleFrom(
-                              backgroundColor: _editingItem.answer.first == 'O'
-                                  ? AppColors.neonPurple
-                                  : Colors.white.withValues(alpha: 0.07),
-                              foregroundColor: _editingItem.answer.first == 'O'
-                                  ? Colors.white
-                                  : Colors.white38,
+                              backgroundColor:
+                                  _editingItem.answer.first == 'O'
+                                      ? AppColors.neonPurple
+                                      : Colors.white.withValues(alpha: 0.07),
+                              foregroundColor:
+                                  _editingItem.answer.first == 'O'
+                                      ? Colors.white
+                                      : Colors.white38,
                             ),
                             onPressed: () => setState(() {
                               _editingItem.answer = <String>['O'];
@@ -1502,12 +1583,14 @@ class _QuizEditFormState extends State<_QuizEditForm> {
                         Expanded(
                           child: OutlinedButton(
                             style: OutlinedButton.styleFrom(
-                              backgroundColor: _editingItem.answer.first == 'X'
-                                  ? AppColors.neonPurple
-                                  : Colors.white.withValues(alpha: 0.07),
-                              foregroundColor: _editingItem.answer.first == 'X'
-                                  ? Colors.white
-                                  : Colors.white38,
+                              backgroundColor:
+                                  _editingItem.answer.first == 'X'
+                                      ? AppColors.neonPurple
+                                      : Colors.white.withValues(alpha: 0.07),
+                              foregroundColor:
+                                  _editingItem.answer.first == 'X'
+                                      ? Colors.white
+                                      : Colors.white38,
                             ),
                             onPressed: () => setState(() {
                               _editingItem.answer = <String>['X'];

--- a/lib/features/addgift/presentation/views/quiz_setting_view.dart
+++ b/lib/features/addgift/presentation/views/quiz_setting_view.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/router/app_router.dart';
 import '../../../../core/widgets/grid_background_painter.dart';
+import '../../../../core/widgets/packaging_loading_overlay.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../application/quiz_setting/quiz_setting_bloc.dart';
 import '../../model/quiz_setting_models.dart';
@@ -164,9 +165,14 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
   // --- [이미지 픽커 유틸] ---
 
   Future<void> _pickImageForReward(bool isSuccessReward) async {
+    final QuizSettingState s = context.read<QuizSettingBloc>().state;
+    // 이미지가 없는 보상 슬롯에서 한도(10개) 도달 시 피커를 열지 않음
+    final bool alreadyHasImage = isSuccessReward
+        ? s.successReward.imageFile != null
+        : s.failReward.imageFile != null;
+    if (!alreadyHasImage && s.imageCount >= 10) return;
     final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
     if (!mounted || image == null) return;
-    final QuizSettingState s = context.read<QuizSettingBloc>().state;
     if (isSuccessReward) {
       context.read<QuizSettingBloc>().add(
         UpdateSuccessReward(
@@ -262,9 +268,13 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
 
     final bool isMobile = MediaQuery.sizeOf(context).width < 800;
 
+    final bool isImageLimitReached =
+        context.read<QuizSettingBloc>().state.imageCount >= 10;
+
     final Widget form = QuizEditForm(
       item: editingItem,
       isDesktop: !isMobile,
+      isImageLimitReached: isImageLimitReached,
       onSave: (QuizItemData updatedItem) {
         final List<QuizItemData> current =
             context.read<QuizSettingBloc>().state.uiItems;
@@ -389,7 +399,9 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
           return Title(
             title: '선물 포장하기 - Gifo',
             color: AppColors.darkBg,
-            child: Scaffold(
+            child: PopScope(
+              canPop: !_isSubmitting,
+              child: Scaffold(
               backgroundColor: AppColors.darkBg,
               appBar: AppBar(
                 toolbarHeight: 68,
@@ -475,10 +487,13 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                             ],
                           ),
                   ),
+                  // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
+                  if (_isSubmitting) const PackagingLoadingOverlay(),
                 ],
               ),
               bottomNavigationBar:
                   isMobile ? _buildMobileBottomBar() : null,
+            ),
             ),
           );
         },

--- a/lib/features/addgift/presentation/views/quiz_setting_view.dart
+++ b/lib/features/addgift/presentation/views/quiz_setting_view.dart
@@ -9,6 +9,10 @@ import '../../../../core/widgets/grid_background_painter.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../../application/quiz_setting/quiz_setting_bloc.dart';
 import '../../model/quiz_setting_models.dart';
+import '../widgets/quiz/quiz_edit_form.dart';
+import '../widgets/quiz/quiz_list_item.dart';
+import '../widgets/quiz/quiz_settings_panel.dart';
+import '../widgets/step_indicator.dart';
 
 class QuizSettingView extends StatelessWidget {
   const QuizSettingView({super.key});
@@ -258,7 +262,7 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
 
     final bool isMobile = MediaQuery.sizeOf(context).width < 800;
 
-    final Widget form = _QuizEditForm(
+    final Widget form = QuizEditForm(
       item: editingItem,
       isDesktop: !isMobile,
       onSave: (QuizItemData updatedItem) {
@@ -394,7 +398,7 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                 elevation: 0,
                 iconTheme: const IconThemeData(color: Colors.white),
                 title: isMobile ? null : _buildTitleBar(),
-                actions: <Widget>[_buildStepIndicator()],
+                actions: <Widget>[const StepIndicator(activeStep: 3)],
               ),
               body: Stack(
                 children: <Widget>[
@@ -452,9 +456,13 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                                     children: <Widget>[
                                       Expanded(
                                         child: SingleChildScrollView(
-                                          child: _buildSettingsSection(
-                                            quizState,
+                                          child: QuizSettingsPanel(
+                                            quizState: quizState,
                                             isMobile: false,
+                                            successRewardNameController: _successRewardNameController,
+                                            failRewardNameController: _failRewardNameController,
+                                            onPickSuccessRewardImage: () => _pickImageForReward(true),
+                                            onPickFailRewardImage: () => _pickImageForReward(false),
                                           ),
                                         ),
                                       ),
@@ -475,55 +483,6 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
           );
         },
       ),
-    );
-  }
-
-  Widget _buildStepIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 20.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildCircle(isActive: true, number: '1'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '2'),
-          _buildLine(isActive: true),
-          _buildCircle(isActive: true, number: '3'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCircle({required bool isActive, required String number}) {
-    return Container(
-      width: 28,
-      height: 28,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: isActive ? AppColors.neonPurple : Colors.white12,
-        border: isActive ? null : Border.all(color: Colors.white24),
-      ),
-      child: Center(
-        child: Text(
-          number,
-          style: TextStyle(
-            fontFamily: 'WantedSans',
-            color: isActive ? Colors.white : Colors.white38,
-            fontSize: 13,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLine({required bool isActive}) {
-    return Container(
-      width: 16,
-      height: 2,
-      color: isActive
-          ? AppColors.neonPurple.withValues(alpha: 0.5)
-          : Colors.white12,
     );
   }
 
@@ -688,7 +647,12 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                     },
                     itemBuilder: (BuildContext context, int index) {
                       final QuizItemData item = quizState.uiItems[index];
-                      return _buildQuizListItem(item, index);
+                      return QuizListItem(
+                        item: item,
+                        index: index,
+                        onRemove: () => _removeItem(item.id),
+                        onTap: () => _showEditModal(item),
+                      );
                     },
                   ),
           ),
@@ -698,286 +662,6 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
     );
   }
 
-  Widget _buildQuizListItem(QuizItemData item, int index) {
-    return Card(
-      key: ValueKey<String>(item.id),
-      color: Colors.white.withValues(alpha: 0.05),
-      margin: const EdgeInsets.only(bottom: 16),
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        side: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: ListTile(
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        leading: ReorderableDragStartListener(
-          index: index,
-          child: const Icon(Icons.menu, color: Colors.white38),
-        ),
-        title: Row(
-          children: <Widget>[
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: AppColors.neonPurple.withValues(alpha: 0.2),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                item.typeName,
-                style: const TextStyle(
-                  color: AppColors.neonPurple,
-                  fontSize: 12,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                'Q. ${item.title.isEmpty ? '(제목 없음)' : item.title}',
-                style: const TextStyle(
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
-        subtitle: Padding(
-          padding: const EdgeInsets.only(top: 8.0),
-          child: Text(
-            'A. ${item.answer.isEmpty ? '(정답 없음)' : item.answer.join(", ")}',
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(color: Colors.white54),
-          ),
-        ),
-        trailing: IconButton(
-          icon: const Icon(Icons.close, size: 24, color: Colors.red),
-          onPressed: () => _removeItem(item.id),
-        ),
-        onTap: () => _showEditModal(item),
-      ),
-    );
-  }
-
-  Widget _buildSettingsSection(
-    QuizSettingState quizState, {
-    required bool isMobile,
-  }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        if (!isMobile) const SizedBox(height: 24),
-        Container(
-          padding: const EdgeInsets.all(24),
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.06),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Wrap(
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: <Widget>[
-                  const Text(
-                    '맞춘 문제가 ',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                    ),
-                  ),
-                  DropdownButtonHideUnderline(
-                    child: DropdownButton<int>(
-                      value: quizState.uiItems.isEmpty
-                          ? 1
-                          : (quizState.successReward.requiredCount! >
-                                    quizState.uiItems.length
-                                ? quizState.uiItems.length
-                                : quizState.successReward.requiredCount),
-                      alignment: Alignment.center,
-                      style: const TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
-                      ),
-                      icon: const Icon(
-                        Icons.keyboard_arrow_down,
-                        size: 20,
-                        color: Colors.white38,
-                      ),
-                      items: List<int>.generate(
-                            quizState.uiItems.isEmpty
-                                ? 1
-                                : quizState.uiItems.length,
-                            (int index) => index + 1,
-                          )
-                          .map(
-                            (int value) => DropdownMenuItem<int>(
-                              value: value,
-                              child: Text('$value개'),
-                            ),
-                          )
-                          .toList(),
-                      onChanged: quizState.uiItems.isEmpty
-                          ? null
-                          : (int? newVal) {
-                              if (newVal != null) {
-                                context.read<QuizSettingBloc>().add(
-                                  UpdateSuccessReward(
-                                    QuizRewardData(
-                                      requiredCount: newVal,
-                                      itemName:
-                                          quizState.successReward.itemName,
-                                      imageFile:
-                                          quizState.successReward.imageFile,
-                                    ),
-                                  ),
-                                );
-                              }
-                            },
-                    ),
-                  ),
-                  const Text(
-                    ' 일 때',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  _buildRewardImagePicker(true, quizState),
-                  const SizedBox(height: 16),
-                  _buildRewardNameInput(isSuccess: true),
-                ],
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 16),
-        Container(
-          padding: const EdgeInsets.all(24),
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.06),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              const Text(
-                '그 외 (실패 보상 등)',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  _buildRewardImagePicker(false, quizState),
-                  const SizedBox(height: 16),
-                  _buildRewardNameInput(isSuccess: false),
-                ],
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 40),
-        const Text(
-          'BGM 설정',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-          ),
-        ),
-        const SizedBox(height: 8),
-        Container(
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            border: Border.all(
-              color: Colors.white.withValues(alpha: 0.12),
-              width: 1,
-            ),
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              const Text(
-                '메인 BGM :',
-                style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      decoration: BoxDecoration(
-                        color: Colors.white12,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: DropdownButtonHideUnderline(
-                        child: DropdownButton<String>(
-                          value: quizState.selectedBgm,
-                          isExpanded: true,
-                          dropdownColor: const Color(0xFF1A1A1A),
-                          style: const TextStyle(color: Colors.white),
-                          iconEnabledColor: Colors.white38,
-                          onChanged: (String? val) {
-                            if (val != null) {
-                              context.read<QuizSettingBloc>().add(
-                                UpdateQuizBgm(val),
-                              );
-                            }
-                          },
-                          items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
-                              .map(
-                                (String value) => DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(
-                                    value,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
-                              )
-                              .toList(),
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: Colors.white12,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: const Icon(Icons.play_arrow, color: Colors.white38),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
 
   Widget _buildCompleteButton() {
     return SizedBox(
@@ -1000,57 +684,6 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
           ),
         ),
       ),
-    );
-  }
-
-  Widget _buildRewardImagePicker(bool isSuccess, QuizSettingState quizState) {
-    final XFile? imageFile = isSuccess
-        ? quizState.successReward.imageFile
-        : quizState.failReward.imageFile;
-    return InkWell(
-      onTap: () => _pickImageForReward(isSuccess),
-      child: Container(
-        height: 80,
-        decoration: BoxDecoration(
-          color: Colors.white12,
-          borderRadius: BorderRadius.circular(8),
-          image: imageFile != null
-              ? DecorationImage(
-                  image: NetworkImage(imageFile.path),
-                  fit: BoxFit.cover,
-                )
-              : null,
-        ),
-        child: imageFile == null
-            ? const Center(
-                child: Text(
-                  '물품 사진',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              )
-            : null,
-      ),
-    );
-  }
-
-  Widget _buildRewardNameInput({required bool isSuccess}) {
-    return TextFormField(
-      controller: isSuccess
-          ? _successRewardNameController
-          : _failRewardNameController,
-      decoration: InputDecoration(
-        hintText: '물품 이름',
-        filled: true,
-        fillColor: Colors.white12,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: BorderSide.none,
-        ),
-      ),
-      style: const TextStyle(color: Colors.white),
     );
   }
 
@@ -1157,7 +790,14 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                           ),
                         ),
                         const SizedBox(height: 24),
-                        _buildSettingsSection(quizState, isMobile: true),
+                        QuizSettingsPanel(
+                          quizState: quizState,
+                          isMobile: true,
+                          successRewardNameController: _successRewardNameController,
+                          failRewardNameController: _failRewardNameController,
+                          onPickSuccessRewardImage: () => _pickImageForReward(true),
+                          onPickFailRewardImage: () => _pickImageForReward(false),
+                        ),
                         const SizedBox(height: 16),
                         SizedBox(
                           width: double.infinity,
@@ -1192,477 +832,6 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
           ),
         );
       },
-    );
-  }
-}
-
-class _QuizEditForm extends StatefulWidget {
-  final QuizItemData item;
-  final ValueChanged<QuizItemData> onSave;
-  final bool isDesktop;
-
-  const _QuizEditForm({
-    required this.item,
-    required this.onSave,
-    this.isDesktop = false,
-  });
-
-  @override
-  State<_QuizEditForm> createState() => _QuizEditFormState();
-}
-
-class _QuizEditFormState extends State<_QuizEditForm> {
-  late QuizItemData _editingItem;
-
-  final TextEditingController _titleController = TextEditingController();
-  final TextEditingController _descController = TextEditingController();
-  final TextEditingController _hintController = TextEditingController();
-
-  // 객관식 답변들 컨트롤러 목록
-  final List<TextEditingController> _optionControllers =
-      <TextEditingController>[];
-  // 정답을 다루기 위한 컨트롤러들
-  final List<TextEditingController> _answerControllers =
-      <TextEditingController>[];
-
-  // 객관식 답변 다중 선택 인덱스
-  final Set<int> _selectedMultipleChoiceAnswers = <int>{};
-
-  @override
-  void initState() {
-    super.initState();
-    _editingItem = widget.item;
-
-    _titleController.text = _editingItem.title;
-    _descController.text = _editingItem.description;
-    _hintController.text = _editingItem.hint;
-
-    if (_editingItem.type == QuizType.multipleChoice) {
-      if (_editingItem.options.isEmpty) {
-        _optionControllers.add(TextEditingController());
-        _optionControllers.add(TextEditingController());
-      } else {
-        for (final String opt in _editingItem.options) {
-          _optionControllers.add(TextEditingController(text: opt));
-        }
-      }
-      for (final String ans in _editingItem.answer) {
-        final int? idx = int.tryParse(ans);
-        if (idx != null) {
-          _selectedMultipleChoiceAnswers.add(idx);
-        } else {
-          // 기존 데이터 호환: 텍스트로 저장된 경우 인덱스를 찾음
-          final int foundIdx = _editingItem.options.indexOf(ans);
-          if (foundIdx != -1) {
-            _selectedMultipleChoiceAnswers.add(foundIdx);
-          }
-        }
-      }
-    } else if (_editingItem.type == QuizType.subjective) {
-      if (_editingItem.answer.isEmpty) {
-        _answerControllers.add(TextEditingController());
-      } else {
-        for (final String ans in _editingItem.answer) {
-          _answerControllers.add(TextEditingController(text: ans));
-        }
-      }
-    } else if (_editingItem.type == QuizType.ox) {
-      if (_editingItem.answer.isEmpty) {
-        _editingItem.answer = <String>['O'];
-      }
-    }
-  }
-
-  @override
-  void dispose() {
-    _titleController.dispose();
-    _descController.dispose();
-    _hintController.dispose();
-    for (final TextEditingController c in _optionControllers) {
-      c.dispose();
-    }
-    for (final TextEditingController c in _answerControllers) {
-      c.dispose();
-    }
-    super.dispose();
-  }
-
-  void _save() {
-    _editingItem.title = _titleController.text.trim();
-    _editingItem.description = _descController.text.trim();
-    _editingItem.hint = _hintController.text.trim();
-
-    if (_editingItem.type == QuizType.multipleChoice) {
-      _editingItem.options = _optionControllers
-          .map((TextEditingController c) => c.text.trim())
-          .where((String s) => s.isNotEmpty)
-          .toList();
-      _editingItem.answer = _selectedMultipleChoiceAnswers
-          .map((int idx) => idx.toString())
-          .toList();
-    } else if (_editingItem.type == QuizType.subjective) {
-      _editingItem.answer = _answerControllers
-          .map((TextEditingController c) => c.text.trim())
-          .where((String s) => s.isNotEmpty)
-          .toList();
-    }
-
-    widget.onSave(_editingItem);
-  }
-
-  Future<void> _pickImage() async {
-    final ImagePicker picker = ImagePicker();
-    final XFile? image = await picker.pickImage(source: ImageSource.gallery);
-    if (image != null) {
-      setState(() {
-        _editingItem.imageFile = image;
-      });
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      constraints: widget.isDesktop
-          ? null
-          : BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.9),
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: AppColors.darkBg,
-        borderRadius: widget.isDesktop
-            ? BorderRadius.zero
-            : const BorderRadius.only(
-                topLeft: Radius.circular(24),
-                topRight: Radius.circular(24),
-              ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          Center(
-            child: Container(
-              width: 40,
-              height: 4,
-              margin: const EdgeInsets.only(bottom: 24),
-              decoration: BoxDecoration(
-                color: Colors.white24,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
-          Expanded(
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    '${_editingItem.typeName} 문제 설정',
-                    style: const TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-                  _buildSectionTitle('제목 (질문)'),
-                  TextField(
-                    controller: _titleController,
-                    decoration: _inputDecoration('질문을 입력하세요'),
-                  ),
-                  const SizedBox(height: 16),
-                  _buildSectionTitle('이미지 (선택)'),
-                  GestureDetector(
-                    onTap: _pickImage,
-                    child: Container(
-                      height: 120,
-                      decoration: BoxDecoration(
-                        color: Colors.white12,
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(
-                          color: Colors.white.withValues(alpha: 0.15),
-                        ),
-                        image: _editingItem.imageFile != null
-                            ? DecorationImage(
-                                image: NetworkImage(
-                                  _editingItem.imageFile!.path,
-                                ),
-                                fit: BoxFit.cover,
-                              )
-                            : null,
-                      ),
-                      child: _editingItem.imageFile == null
-                          ? const Center(
-                              child: Icon(
-                                Icons.add_photo_alternate,
-                                size: 40,
-                                color: Colors.white24,
-                              ),
-                            )
-                          : null,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  _buildSectionTitle('설명'),
-                  TextField(
-                    controller: _descController,
-                    decoration: _inputDecoration('문제에 대한 설명을 입력하세요'),
-                  ),
-                  const SizedBox(height: 16),
-                  _buildSectionTitle('힌트'),
-                  TextField(
-                    controller: _hintController,
-                    decoration: _inputDecoration('문제에 대한 힌트를 입력하세요'),
-                  ),
-                  const SizedBox(height: 24),
-
-                  if (_editingItem.type == QuizType.multipleChoice) ...<Widget>[
-                    _buildSectionTitle('선택지'),
-                    ..._optionControllers.asMap().entries.map((
-                      MapEntry<int, TextEditingController> entry,
-                    ) {
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 8.0),
-                        child: Row(
-                          children: <Widget>[
-                            Text('${entry.key + 1}. '),
-                            Expanded(
-                              child: TextField(
-                                controller: entry.value,
-                                decoration: _inputDecoration(
-                                  '선택지 ${entry.key + 1}',
-                                ),
-                              ),
-                            ),
-                            IconButton(
-                              icon: const Icon(
-                                Icons.remove_circle,
-                                color: Colors.red,
-                              ),
-                              onPressed: () {
-                                setState(() {
-                                  _optionControllers.removeAt(entry.key);
-                                  // 선택된 인덱스들 갱신 로직
-                                  if (_selectedMultipleChoiceAnswers.contains(
-                                    entry.key,
-                                  )) {
-                                    _selectedMultipleChoiceAnswers.remove(
-                                      entry.key,
-                                    );
-                                  }
-                                  final Set<int> newAnswers = <int>{};
-                                  for (final int ans
-                                      in _selectedMultipleChoiceAnswers) {
-                                    if (ans > entry.key) {
-                                      newAnswers.add(ans - 1);
-                                    } else {
-                                      newAnswers.add(ans);
-                                    }
-                                  }
-                                  _selectedMultipleChoiceAnswers.clear();
-                                  _selectedMultipleChoiceAnswers.addAll(
-                                    newAnswers,
-                                  );
-                                });
-                              },
-                            ),
-                          ],
-                        ),
-                      );
-                    }),
-                    TextButton.icon(
-                      onPressed: () {
-                        setState(() {
-                          _optionControllers.add(TextEditingController());
-                        });
-                      },
-                      icon: const Icon(Icons.add),
-                      label: const Text('선택지 추가'),
-                    ),
-                    const SizedBox(height: 16),
-                    _buildSectionTitle('정답 선택 (복수 선택 가능)'),
-                    Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      children: List<Widget>.generate(
-                        _optionControllers.length,
-                        (int index) {
-                          final bool isSelected =
-                              _selectedMultipleChoiceAnswers.contains(index);
-                          return ChoiceChip(
-                            label: Text('${index + 1}번'),
-                            selected: isSelected,
-                            onSelected: (bool selected) {
-                              setState(() {
-                                if (selected) {
-                                  _selectedMultipleChoiceAnswers.add(index);
-                                } else {
-                                  _selectedMultipleChoiceAnswers.remove(index);
-                                }
-                              });
-                            },
-                            selectedColor: AppColors.neonPurple,
-                            labelStyle: TextStyle(
-                              color:
-                                  isSelected ? Colors.white : Colors.white38,
-                              fontWeight: FontWeight.bold,
-                            ),
-                            backgroundColor:
-                                Colors.white.withValues(alpha: 0.07),
-                          );
-                        },
-                      ),
-                    ),
-                  ] else if (_editingItem.type ==
-                      QuizType.subjective) ...<Widget>[
-                    _buildSectionTitle('정답 목록 (유사 답변 포함)'),
-                    ..._answerControllers.asMap().entries.map((
-                      MapEntry<int, TextEditingController> entry,
-                    ) {
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 8.0),
-                        child: Row(
-                          children: <Widget>[
-                            Expanded(
-                              child: TextField(
-                                controller: entry.value,
-                                decoration: _inputDecoration('정답 형태 입력'),
-                              ),
-                            ),
-                            IconButton(
-                              icon: const Icon(
-                                Icons.remove_circle,
-                                color: Colors.red,
-                              ),
-                              onPressed: () {
-                                setState(() {
-                                  _answerControllers.removeAt(entry.key);
-                                });
-                              },
-                            ),
-                          ],
-                        ),
-                      );
-                    }),
-                    TextButton.icon(
-                      onPressed: () {
-                        setState(() {
-                          _answerControllers.add(TextEditingController());
-                        });
-                      },
-                      icon: const Icon(Icons.add),
-                      label: const Text('정답 형태 추가'),
-                    ),
-                  ] else if (_editingItem.type == QuizType.ox) ...<Widget>[
-                    _buildSectionTitle('정답'),
-                    Row(
-                      children: <Widget>[
-                        Expanded(
-                          child: OutlinedButton(
-                            style: OutlinedButton.styleFrom(
-                              backgroundColor:
-                                  _editingItem.answer.first == 'O'
-                                      ? AppColors.neonPurple
-                                      : Colors.white.withValues(alpha: 0.07),
-                              foregroundColor:
-                                  _editingItem.answer.first == 'O'
-                                      ? Colors.white
-                                      : Colors.white38,
-                            ),
-                            onPressed: () => setState(() {
-                              _editingItem.answer = <String>['O'];
-                            }),
-                            child: const Text(
-                              'O',
-                              style: TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 16),
-                        Expanded(
-                          child: OutlinedButton(
-                            style: OutlinedButton.styleFrom(
-                              backgroundColor:
-                                  _editingItem.answer.first == 'X'
-                                      ? AppColors.neonPurple
-                                      : Colors.white.withValues(alpha: 0.07),
-                              foregroundColor:
-                                  _editingItem.answer.first == 'X'
-                                      ? Colors.white
-                                      : Colors.white38,
-                            ),
-                            onPressed: () => setState(() {
-                              _editingItem.answer = <String>['X'];
-                            }),
-                            child: const Text(
-                              'X',
-                              style: TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                  const SizedBox(height: 40),
-                ],
-              ),
-            ),
-          ),
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton(
-              onPressed: _save,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.neonPurple,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-              ),
-              child: const Text(
-                '저장 완료',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSectionTitle(String title) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8.0),
-      child: Text(
-        title,
-        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-      ),
-    );
-  }
-
-  InputDecoration _inputDecoration(String hint) {
-    return InputDecoration(
-      hintText: hint,
-      filled: true,
-      fillColor: Colors.white.withValues(alpha: 0.07),
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(8),
-        borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(8),
-        borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(8),
-        borderSide: const BorderSide(color: AppColors.neonPurple),
-      ),
     );
   }
 }

--- a/lib/features/addgift/presentation/views/quiz_setting_view.dart
+++ b/lib/features/addgift/presentation/views/quiz_setting_view.dart
@@ -49,8 +49,9 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
   @override
   void initState() {
     super.initState();
-    final GiftPackagingState packagingState =
-        context.read<GiftPackagingBloc>().state;
+    final GiftPackagingState packagingState = context
+        .read<GiftPackagingBloc>()
+        .state;
     if (packagingState.receiverName.isNotEmpty) {
       _userNameController.text = packagingState.receiverName;
     }
@@ -124,8 +125,9 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
 
   void _removeItem(String itemId) {
     final QuizSettingState s = context.read<QuizSettingBloc>().state;
-    final List<QuizItemData> updated =
-        s.uiItems.where((QuizItemData e) => e.id != itemId).toList();
+    final List<QuizItemData> updated = s.uiItems
+        .where((QuizItemData e) => e.id != itemId)
+        .toList();
     context.read<QuizSettingBloc>().add(UpdateQuizItems(updated));
     final int currentCount = s.successReward.requiredCount ?? 1;
     if (updated.isEmpty) {
@@ -152,8 +154,9 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
   }
 
   void _onReorder(int oldIndex, int newIndex) {
-    final List<QuizItemData> items =
-        List<QuizItemData>.from(context.read<QuizSettingBloc>().state.uiItems);
+    final List<QuizItemData> items = List<QuizItemData>.from(
+      context.read<QuizSettingBloc>().state.uiItems,
+    );
     if (newIndex > oldIndex) {
       newIndex -= 1;
     }
@@ -186,10 +189,7 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
     } else {
       context.read<QuizSettingBloc>().add(
         UpdateFailReward(
-          QuizRewardData(
-            itemName: s.failReward.itemName,
-            imageFile: image,
-          ),
+          QuizRewardData(itemName: s.failReward.itemName, imageFile: image),
         ),
       );
     }
@@ -276,23 +276,25 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
       isDesktop: !isMobile,
       isImageLimitReached: isImageLimitReached,
       onSave: (QuizItemData updatedItem) {
-        final List<QuizItemData> current =
-            context.read<QuizSettingBloc>().state.uiItems;
+        final List<QuizItemData> current = context
+            .read<QuizSettingBloc>()
+            .state
+            .uiItems;
         if (isNew) {
           context.read<QuizSettingBloc>().add(
             UpdateQuizItems(<QuizItemData>[...current, updatedItem]),
           );
         } else {
-          final int index =
-              current.indexWhere((QuizItemData e) => e.id == updatedItem.id);
+          final int index = current.indexWhere(
+            (QuizItemData e) => e.id == updatedItem.id,
+          );
           if (index != -1) {
-            final List<QuizItemData> updated =
-                List<QuizItemData>.from(current);
+            final List<QuizItemData> updated = List<QuizItemData>.from(current);
             updated[index] = updatedItem;
             context.read<QuizSettingBloc>().add(UpdateQuizItems(updated));
           }
         }
-        Navigator.pop(context);
+        Navigator.of(context, rootNavigator: !isMobile).pop();
       },
     );
 
@@ -315,43 +317,46 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
     } else {
       showGeneralDialog(
         context: context,
+        useRootNavigator: true,
         barrierDismissible: true,
         barrierLabel: 'Dismiss',
         barrierColor: Colors.black54,
         transitionDuration: const Duration(milliseconds: 300),
-        pageBuilder: (
-          BuildContext context,
-          Animation<double> animation,
-          Animation<double> secondaryAnimation,
-        ) {
-          return SafeArea(
-            child: Align(
-              alignment: Alignment.centerRight,
-              child: Material(
-                color: Colors.transparent,
-                child: SizedBox(
-                  width: 500,
-                  height: double.infinity,
-                  child: form,
+        pageBuilder:
+            (
+              BuildContext context,
+              Animation<double> animation,
+              Animation<double> secondaryAnimation,
+            ) {
+              return SafeArea(
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: Material(
+                    color: Colors.transparent,
+                    child: SizedBox(
+                      width: 500,
+                      height: double.infinity,
+                      child: form,
+                    ),
+                  ),
                 ),
-              ),
-            ),
-          );
-        },
-        transitionBuilder: (
-          BuildContext context,
-          Animation<double> animation,
-          Animation<double> secondaryAnimation,
-          Widget child,
-        ) {
-          return SlideTransition(
-            position: Tween<Offset>(
-              begin: const Offset(1, 0),
-              end: Offset.zero,
-            ).animate(animation),
-            child: child,
-          );
-        },
+              );
+            },
+        transitionBuilder:
+            (
+              BuildContext context,
+              Animation<double> animation,
+              Animation<double> secondaryAnimation,
+              Widget child,
+            ) {
+              return SlideTransition(
+                position: Tween<Offset>(
+                  begin: const Offset(1, 0),
+                  end: Offset.zero,
+                ).animate(animation),
+                child: child,
+              );
+            },
       );
     }
   }
@@ -360,6 +365,10 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
 
   void _completePackage() {
     final GiftPackagingBloc packagingBloc = context.read<GiftPackagingBloc>();
+    final QuizSettingState quizState = context.read<QuizSettingBloc>().state;
+    debugPrint(
+      '[QuizSettingView] 포장 완료 클릭 - 문제수=${quizState.uiItems.length}, 이미지수=${quizState.imageCount}, 받는이="${_userNameController.text.trim()}"',
+    );
     context.read<QuizSettingBloc>().add(
       SubmitQuizSetting(
         receiverName: _userNameController.text.trim(),
@@ -402,98 +411,101 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
             child: PopScope(
               canPop: !_isSubmitting,
               child: Scaffold(
-              backgroundColor: AppColors.darkBg,
-              appBar: AppBar(
-                toolbarHeight: 68,
                 backgroundColor: AppColors.darkBg,
-                surfaceTintColor: Colors.transparent,
-                elevation: 0,
-                iconTheme: const IconThemeData(color: Colors.white),
-                title: isMobile ? null : _buildTitleBar(),
-                actions: <Widget>[const StepIndicator(activeStep: 3)],
-              ),
-              body: Stack(
-                children: <Widget>[
-                  Positioned.fill(
-                    child: CustomPaint(painter: GridBackgroundPainter()),
-                  ),
-                  SafeArea(
-                    child: isMobile
-                        ? Column(
-                            children: <Widget>[
-                              Padding(
-                                padding: const EdgeInsets.all(24.0),
-                                child: SingleChildScrollView(
-                                  scrollDirection: Axis.horizontal,
-                                  child: _buildTitleBar(),
-                                ),
-                              ),
-                              Expanded(
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 24.0,
-                                  ),
-                                  child: _buildItemsSection(
-                                    isMobile,
-                                    quizState,
+                appBar: AppBar(
+                  toolbarHeight: 68,
+                  backgroundColor: AppColors.darkBg,
+                  surfaceTintColor: Colors.transparent,
+                  elevation: 0,
+                  iconTheme: const IconThemeData(color: Colors.white),
+                  title: isMobile ? null : _buildTitleBar(),
+                  actions: const <Widget>[StepIndicator(activeStep: 3)],
+                ),
+                body: Stack(
+                  children: <Widget>[
+                    Positioned.fill(
+                      child: CustomPaint(painter: GridBackgroundPainter()),
+                    ),
+                    SafeArea(
+                      child: isMobile
+                          ? Column(
+                              children: <Widget>[
+                                Padding(
+                                  padding: const EdgeInsets.all(24.0),
+                                  child: SingleChildScrollView(
+                                    scrollDirection: Axis.horizontal,
+                                    child: _buildTitleBar(),
                                   ),
                                 ),
-                              ),
-                            ],
-                          )
-                        : Row(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: <Widget>[
-                              Expanded(
-                                flex: 7,
-                                child: Padding(
-                                  padding: const EdgeInsets.all(40.0),
-                                  child: _buildItemsSection(
-                                    isMobile,
-                                    quizState,
+                                Expanded(
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 24.0,
+                                    ),
+                                    child: _buildItemsSection(
+                                      isMobile,
+                                      quizState,
+                                    ),
                                   ),
                                 ),
-                              ),
-                              Container(
-                                width: 1,
-                                color: Colors.white.withValues(alpha: 0.1),
-                              ),
-                              Expanded(
-                                flex: 3,
-                                child: Padding(
-                                  padding: const EdgeInsets.all(40.0),
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    children: <Widget>[
-                                      Expanded(
-                                        child: SingleChildScrollView(
-                                          child: QuizSettingsPanel(
-                                            quizState: quizState,
-                                            isMobile: false,
-                                            successRewardNameController: _successRewardNameController,
-                                            failRewardNameController: _failRewardNameController,
-                                            onPickSuccessRewardImage: () => _pickImageForReward(true),
-                                            onPickFailRewardImage: () => _pickImageForReward(false),
+                              ],
+                            )
+                          : Row(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: <Widget>[
+                                Expanded(
+                                  flex: 7,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(40.0),
+                                    child: _buildItemsSection(
+                                      isMobile,
+                                      quizState,
+                                    ),
+                                  ),
+                                ),
+                                Container(
+                                  width: 1,
+                                  color: Colors.white.withValues(alpha: 0.1),
+                                ),
+                                Expanded(
+                                  flex: 3,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(40.0),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.stretch,
+                                      children: <Widget>[
+                                        Expanded(
+                                          child: SingleChildScrollView(
+                                            child: QuizSettingsPanel(
+                                              quizState: quizState,
+                                              isMobile: false,
+                                              successRewardNameController:
+                                                  _successRewardNameController,
+                                              failRewardNameController:
+                                                  _failRewardNameController,
+                                              onPickSuccessRewardImage: () =>
+                                                  _pickImageForReward(true),
+                                              onPickFailRewardImage: () =>
+                                                  _pickImageForReward(false),
+                                            ),
                                           ),
                                         ),
-                                      ),
-                                      const SizedBox(height: 24),
-                                      _buildCompleteButton(),
-                                    ],
+                                        const SizedBox(height: 24),
+                                        _buildCompleteButton(),
+                                      ],
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ],
-                          ),
-                  ),
-                  // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
-                  if (_isSubmitting) const PackagingLoadingOverlay(),
-                ],
+                              ],
+                            ),
+                    ),
+                    // 로딩 오버레이: 전송 중 터치 차단 + 프로그레스 표시
+                    if (_isSubmitting) const PackagingLoadingOverlay(),
+                  ],
+                ),
+                bottomNavigationBar: isMobile ? _buildMobileBottomBar() : null,
               ),
-              bottomNavigationBar:
-                  isMobile ? _buildMobileBottomBar() : null,
-            ),
             ),
           );
         },
@@ -543,10 +555,7 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
           ),
         ),
         const SizedBox(width: 8),
-        const Text(
-          '님의',
-          style: TextStyle(fontSize: 16, color: Colors.white70),
-        ),
+        const Text('님의', style: TextStyle(fontSize: 16, color: Colors.white70)),
         const SizedBox(width: 8),
         SizedBox(
           width: 120,
@@ -649,17 +658,14 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                     itemCount: quizState.uiItems.length,
                     onReorder: _onReorder,
                     buildDefaultDragHandles: false,
-                    proxyDecorator: (
-                      Widget child,
-                      int index,
-                      Animation<double> animation,
-                    ) {
-                      return Material(
-                        color: Colors.transparent,
-                        elevation: 0,
-                        child: child,
-                      );
-                    },
+                    proxyDecorator:
+                        (Widget child, int index, Animation<double> animation) {
+                          return Material(
+                            color: Colors.transparent,
+                            elevation: 0,
+                            child: child,
+                          );
+                        },
                     itemBuilder: (BuildContext context, int index) {
                       final QuizItemData item = quizState.uiItems[index];
                       return QuizListItem(
@@ -676,7 +682,6 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
       ],
     );
   }
-
 
   Widget _buildCompleteButton() {
     return SizedBox(
@@ -708,7 +713,7 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         decoration: BoxDecoration(
           color: Colors.white.withValues(alpha: 0.07),
-          border: Border(top: BorderSide(color: Colors.white12)),
+          border: const Border(top: BorderSide(color: Colors.white12)),
         ),
         child: Row(
           children: <Widget>[
@@ -776,9 +781,9 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                   padding: EdgeInsets.only(
                     bottom: MediaQuery.of(innerCtx).viewInsets.bottom,
                   ),
-                  decoration: BoxDecoration(
+                  decoration: const BoxDecoration(
                     color: AppColors.darkBg,
-                    borderRadius: const BorderRadius.vertical(
+                    borderRadius: BorderRadius.vertical(
                       top: Radius.circular(24),
                     ),
                   ),
@@ -808,10 +813,13 @@ class _QuizSettingContentState extends State<_QuizSettingContent> {
                         QuizSettingsPanel(
                           quizState: quizState,
                           isMobile: true,
-                          successRewardNameController: _successRewardNameController,
+                          successRewardNameController:
+                              _successRewardNameController,
                           failRewardNameController: _failRewardNameController,
-                          onPickSuccessRewardImage: () => _pickImageForReward(true),
-                          onPickFailRewardImage: () => _pickImageForReward(false),
+                          onPickSuccessRewardImage: () =>
+                              _pickImageForReward(true),
+                          onPickFailRewardImage: () =>
+                              _pickImageForReward(false),
                         ),
                         const SizedBox(height: 16),
                         SizedBox(

--- a/lib/features/addgift/presentation/views/receiver_name_view.dart
+++ b/lib/features/addgift/presentation/views/receiver_name_view.dart
@@ -6,6 +6,7 @@ import '../../../../core/constants/app_breakpoints.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../widgets/addgift_scaffold.dart';
+import '../widgets/step_indicator.dart';
 
 class ReceiverNameView extends StatefulWidget {
   const ReceiverNameView({super.key});
@@ -45,7 +46,7 @@ class _ReceiverNameViewState extends State<ReceiverNameView> {
           surfaceTintColor: Colors.transparent,
           elevation: 0,
           iconTheme: const IconThemeData(color: Colors.white),
-          actions: <Widget>[_buildStepIndicator()],
+          actions: <Widget>[const StepIndicator(activeStep: 1)],
         ),
         bottomNavigationBar: _buildBottomButton(),
         body: SafeArea(
@@ -236,52 +237,4 @@ class _ReceiverNameViewState extends State<ReceiverNameView> {
     );
   }
 
-  Widget _buildStepIndicator() {
-    return Padding(
-      padding: const EdgeInsets.only(right: 20.0),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildCircle(isActive: true, number: '1'),
-          _buildLine(),
-          _buildCircle(isActive: false, number: '2'),
-          _buildLine(),
-          _buildCircle(isActive: false, number: '3'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCircle({required bool isActive, required String number}) {
-    return Container(
-      width: 28,
-      height: 28,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: isActive ? AppColors.neonPurple : Colors.white12,
-        border: isActive
-            ? null
-            : Border.all(color: Colors.white24, width: 1),
-      ),
-      child: Center(
-        child: Text(
-          number,
-          style: TextStyle(
-            fontFamily: 'WantedSans',
-            color: isActive ? Colors.white : Colors.white38,
-            fontSize: 13,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLine() {
-    return Container(
-      width: 16,
-      height: 2,
-      color: Colors.white12,
-    );
-  }
 }

--- a/lib/features/addgift/presentation/views/receiver_name_view.dart
+++ b/lib/features/addgift/presentation/views/receiver_name_view.dart
@@ -6,6 +6,9 @@ import '../../../../core/constants/app_breakpoints.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../application/gift_packaging_bloc.dart';
 import '../widgets/addgift_scaffold.dart';
+import '../widgets/receiver_name/receiver_name_bottom_button.dart';
+import '../widgets/receiver_name/receiver_name_desktop_layout.dart';
+import '../widgets/receiver_name/receiver_name_mobile_layout.dart';
 import '../widgets/step_indicator.dart';
 
 class ReceiverNameView extends StatefulWidget {
@@ -46,195 +49,26 @@ class _ReceiverNameViewState extends State<ReceiverNameView> {
           surfaceTintColor: Colors.transparent,
           elevation: 0,
           iconTheme: const IconThemeData(color: Colors.white),
-          actions: <Widget>[const StepIndicator(activeStep: 1)],
+          actions: const <Widget>[StepIndicator(activeStep: 1)],
         ),
-        bottomNavigationBar: _buildBottomButton(),
+        bottomNavigationBar: ReceiverNameBottomButton(
+          nameController: _nameController,
+          onNext: _handleNext,
+        ),
         body: SafeArea(
           child: isDesktop
-              ? _buildDesktopLayout()
-              : _buildMobileLayout(isMobile),
+              ? ReceiverNameDesktopLayout(nameController: _nameController)
+              : ReceiverNameMobileLayout(
+                  isMobile: isMobile,
+                  nameController: _nameController,
+                ),
         ),
       ),
     );
   }
 
-  // 데스크톱: 좌우 분할 레이아웃
-  Widget _buildDesktopLayout() {
-    return Row(
-      children: <Widget>[
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 64.0, vertical: 48.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  '선물 받는 분의',
-                  style: TextStyle(
-                    fontFamily: 'PFStardustS',
-                    fontSize: 36,
-                    color: Colors.white.withValues(alpha: 0.9),
-                    height: 1.4,
-                  ),
-                ),
-                Text(
-                  '닉네임을 알려주세요',
-                  style: TextStyle(
-                    fontFamily: 'PFStardustS',
-                    fontSize: 36,
-                    color: AppColors.neonPurple,
-                    height: 1.4,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  '받는 분의 닉네임으로 선물이 포장됩니다.',
-                  style: TextStyle(
-                    fontFamily: 'WantedSans',
-                    fontSize: 15,
-                    color: Colors.white38,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-        Expanded(
-          child: Center(
-            child: SizedBox(
-              width: 400,
-              child: _buildInputField(),
-            ),
-          ),
-        ),
-      ],
-    );
+  void _handleNext(String name) {
+    context.read<GiftPackagingBloc>().add(SetReceiverName(name));
+    context.push('/addgift/memory-decision');
   }
-
-  // 모바일/태블릿: 세로 배치
-  Widget _buildMobileLayout(bool isMobile) {
-    return Padding(
-      padding: EdgeInsets.symmetric(
-        horizontal: isMobile ? 24.0 : 48.0,
-        vertical: 32.0,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          const SizedBox(height: 24),
-          Text(
-            '선물 받는 분의\n닉네임을 알려주세요',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontFamily: 'PFStardustS',
-              fontSize: isMobile ? 24 : 30,
-              color: Colors.white,
-              height: 1.5,
-            ),
-          ),
-          const SizedBox(height: 40),
-          Center(
-            child: SizedBox(
-              width: isMobile ? double.infinity : 400,
-              child: _buildInputField(),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildInputField() {
-    return TextField(
-      textAlign: TextAlign.center,
-      controller: _nameController,
-      style: const TextStyle(
-        fontFamily: 'WantedSans',
-        fontSize: 22,
-        fontWeight: FontWeight.bold,
-        color: Colors.white,
-      ),
-      decoration: InputDecoration(
-        hintText: '닉네임 입력',
-        hintStyle: const TextStyle(
-          fontFamily: 'WantedSans',
-          color: Colors.white38,
-          fontSize: 18,
-        ),
-        filled: true,
-        fillColor: Colors.white.withValues(alpha: 0.07),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 20.0,
-          vertical: 24.0,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(16.0),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2)),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(16.0),
-          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2)),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(16.0),
-          borderSide: const BorderSide(color: AppColors.neonPurple, width: 2.0),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildBottomButton() {
-    return SafeArea(
-      child: ValueListenableBuilder<TextEditingValue>(
-        valueListenable: _nameController,
-        builder: (BuildContext context, TextEditingValue value, Widget? child) {
-          final bool isNameEmpty = value.text.trim().isEmpty;
-          return Padding(
-            padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
-            child: SizedBox(
-              height: 60,
-              child: ElevatedButton(
-                onPressed: isNameEmpty
-                    ? null
-                    : () {
-                        context.read<GiftPackagingBloc>().add(
-                          SetReceiverName(value.text.trim()),
-                        );
-                        context.push('/addgift/memory-decision');
-                      },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.neonPurple,
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: Colors.white12,
-                  disabledForegroundColor: Colors.white38,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16.0),
-                  ),
-                  elevation: 0,
-                ),
-                child: const Row(
-                  mainAxisSize: MainAxisSize.min,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    Text(
-                      '다음',
-                      style: TextStyle(
-                        fontFamily: 'WantedSans',
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    SizedBox(width: 8),
-                    Icon(Icons.arrow_forward_rounded, size: 22),
-                  ],
-                ),
-              ),
-            ),
-          );
-        },
-      ),
-    );
-  }
-
 }

--- a/lib/features/addgift/presentation/widgets/direct_open/after_open_card.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/after_open_card.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class AfterOpenCard extends StatelessWidget {
+  const AfterOpenCard({
+    super.key,
+    required this.isMobile,
+    required this.imageFile,
+    required this.nameController,
+    required this.onPickImage,
+  });
+
+  final bool isMobile;
+  final XFile? imageFile;
+  final TextEditingController nameController;
+  final VoidCallback onPickImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          const Text(
+            '개봉 후',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 16),
+          InkWell(
+            onTap: onPickImage,
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              width: isMobile ? 200 : 280,
+              height: isMobile ? 200 : 280,
+              decoration: BoxDecoration(
+                color: Colors.white12,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 2,
+                ),
+                image: imageFile != null
+                    ? DecorationImage(
+                        image: NetworkImage(imageFile!.path),
+                        fit: BoxFit.cover,
+                      )
+                    : null,
+              ),
+              child: imageFile == null
+                  ? const Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Icon(
+                          Icons.image,
+                          size: 64,
+                          color: Colors.white38,
+                        ),
+                        SizedBox(height: 8),
+                        Text(
+                          '물품 사진 등록',
+                          style: TextStyle(
+                            color: Colors.white38,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    )
+                  : null,
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              '물품 이름',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: nameController,
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              hintText: '상품 이름을 기입해주세요.',
+              hintStyle: const TextStyle(color: Colors.white38),
+              filled: true,
+              fillColor: Colors.white12,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(color: AppColors.pixelPurple),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/direct_open/before_open_card.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/before_open_card.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class BeforeOpenCard extends StatelessWidget {
+  const BeforeOpenCard({
+    super.key,
+    required this.isMobile,
+    required this.imageFile,
+    required this.descController,
+    required this.onPickImage,
+  });
+
+  final bool isMobile;
+  final XFile? imageFile;
+  final TextEditingController descController;
+  final VoidCallback onPickImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          const Text(
+            '개봉 전',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 16),
+          InkWell(
+            onTap: onPickImage,
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              width: isMobile ? 200 : 280,
+              height: isMobile ? 200 : 280,
+              decoration: BoxDecoration(
+                color: Colors.white12,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 2,
+                ),
+                image: imageFile != null
+                    ? DecorationImage(
+                        image: NetworkImage(imageFile!.path),
+                        fit: BoxFit.cover,
+                      )
+                    : null,
+              ),
+              child: imageFile == null
+                  ? const Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Icon(
+                          Icons.card_giftcard,
+                          size: 64,
+                          color: Colors.white38,
+                        ),
+                        SizedBox(height: 8),
+                        Text(
+                          '상자 이미지 변경',
+                          style: TextStyle(
+                            color: Colors.white38,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    )
+                  : null,
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              '설명란 문구',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: descController,
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              hintText: '상자 하단에 보여질 설명을 입력해주세요.',
+              hintStyle: const TextStyle(color: Colors.white38),
+              filled: true,
+              fillColor: Colors.white12,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.15),
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(color: AppColors.pixelPurple),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/direct_open/direct_open_complete_button.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/direct_open_complete_button.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class DirectOpenCompleteButton extends StatelessWidget {
+  const DirectOpenCompleteButton({
+    super.key,
+    required this.onPressed,
+    this.height = 60,
+  });
+
+  final VoidCallback onPressed;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF6DE1F1),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          elevation: 0,
+        ),
+        child: const Text(
+          '포장 완료',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/direct_open/direct_open_content_section.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/direct_open_content_section.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import '../../../application/direct_open_setting/direct_open_setting_bloc.dart';
+import 'after_open_card.dart';
+import 'before_open_card.dart';
+
+class DirectOpenContentSection extends StatelessWidget {
+  const DirectOpenContentSection({
+    super.key,
+    required this.isMobile,
+    required this.state,
+    required this.beforeDescController,
+    required this.afterNameController,
+    required this.onPickBeforeImage,
+    required this.onPickAfterImage,
+  });
+
+  final bool isMobile;
+  final DirectOpenSettingState state;
+  final TextEditingController beforeDescController;
+  final TextEditingController afterNameController;
+  final VoidCallback onPickBeforeImage;
+  final VoidCallback onPickAfterImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (isMobile) ...<Widget>[
+            BeforeOpenCard(
+              isMobile: isMobile,
+              imageFile: state.beforeImageFile,
+              descController: beforeDescController,
+              onPickImage: onPickBeforeImage,
+            ),
+            const SizedBox(height: 24),
+            AfterOpenCard(
+              isMobile: isMobile,
+              imageFile: state.afterImageFile,
+              nameController: afterNameController,
+              onPickImage: onPickAfterImage,
+            ),
+          ] else ...<Widget>[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Expanded(
+                  child: BeforeOpenCard(
+                    isMobile: isMobile,
+                    imageFile: state.beforeImageFile,
+                    descController: beforeDescController,
+                    onPickImage: onPickBeforeImage,
+                  ),
+                ),
+                const SizedBox(width: 32),
+                Expanded(
+                  child: AfterOpenCard(
+                    isMobile: isMobile,
+                    imageFile: state.afterImageFile,
+                    nameController: afterNameController,
+                    onPickImage: onPickAfterImage,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/direct_open/direct_open_mobile_bottom_bar.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/direct_open_mobile_bottom_bar.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import 'direct_open_complete_button.dart';
+
+class DirectOpenMobileBottomBar extends StatelessWidget {
+  const DirectOpenMobileBottomBar({
+    super.key,
+    required this.onShowSettings,
+    required this.onComplete,
+  });
+
+  final VoidCallback onShowSettings;
+  final VoidCallback onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.07),
+          border: const Border(top: BorderSide(color: Colors.white12)),
+        ),
+        child: Row(
+          children: <Widget>[
+            InkWell(
+              onTap: onShowSettings,
+              borderRadius: BorderRadius.circular(16),
+              child: Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.07),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    width: 2,
+                  ),
+                ),
+                child: const Icon(Icons.settings, color: Colors.white60),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: DirectOpenCompleteButton(
+                onPressed: onComplete,
+                height: 56,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/direct_open/direct_open_settings_section.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/direct_open_settings_section.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../application/direct_open_setting/direct_open_setting_bloc.dart';
+
+class DirectOpenSettingsSection extends StatelessWidget {
+  const DirectOpenSettingsSection({super.key, required this.state});
+
+  final DirectOpenSettingState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Text(
+          'BGM (배경음악)',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  color: Colors.white12,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: state.selectedBgm,
+                    isExpanded: true,
+                    dropdownColor: const Color(0xFF1A1A1A),
+                    style: const TextStyle(color: Colors.white),
+                    iconEnabledColor: Colors.white38,
+                    onChanged: (String? val) {
+                      if (val != null) {
+                        context.read<DirectOpenSettingBloc>().add(
+                          UpdateDirectOpenBgm(val),
+                        );
+                      }
+                    },
+                    items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
+                        .map(
+                          (String value) => DropdownMenuItem<String>(
+                            value: value,
+                            child: Text(value, overflow: TextOverflow.ellipsis),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: Colors.white12,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Icon(Icons.play_arrow, color: Colors.white38),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/direct_open/direct_open_step_indicator.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/direct_open_step_indicator.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class DirectOpenStepIndicator extends StatelessWidget {
+  const DirectOpenStepIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.only(right: 20.0),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          _DirectOpenStepCircle(number: '1'),
+          _DirectOpenStepLine(),
+          _DirectOpenStepCircle(number: '2'),
+          _DirectOpenStepLine(),
+          _DirectOpenStepCircle(number: '3'),
+        ],
+      ),
+    );
+  }
+}
+
+class _DirectOpenStepCircle extends StatelessWidget {
+  const _DirectOpenStepCircle({required this.number});
+
+  final String number;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 28,
+      height: 28,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: AppColors.pixelPurple,
+      ),
+      child: Center(
+        child: Text(
+          number,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DirectOpenStepLine extends StatelessWidget {
+  const _DirectOpenStepLine();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 16,
+      height: 2,
+      color: AppColors.pixelPurple.withValues(alpha: 0.5),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/direct_open/direct_open_title_bar.dart
+++ b/lib/features/addgift/presentation/widgets/direct_open/direct_open_title_bar.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class DirectOpenTitleBar extends StatelessWidget {
+  const DirectOpenTitleBar({
+    super.key,
+    required this.userNameController,
+    required this.subTitleController,
+    this.suffixLabel = '선물 개봉',
+  });
+
+  final TextEditingController userNameController;
+  final TextEditingController subTitleController;
+  final String suffixLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 100,
+          child: TextFormField(
+            controller: userNameController,
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              hintText: '닉네임',
+              hintStyle: const TextStyle(color: Colors.white38),
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 12,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(
+                  color: AppColors.pixelPurple,
+                  width: 1.5,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        const Text('님의', style: TextStyle(fontSize: 16, color: Colors.white70)),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 120,
+          child: TextFormField(
+            controller: subTitleController,
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              hintText: '서브 타이틀',
+              hintStyle: const TextStyle(color: Colors.white38),
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 12,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(
+                  color: AppColors.pixelPurple,
+                  width: 1.5,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          suffixLabel,
+          style: const TextStyle(fontSize: 16, color: Colors.white70),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_capsule_item.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_capsule_item.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+
+import '../../../application/gacha_setting/gacha_setting_bloc.dart';
+
+class GachaCapsuleItem extends StatelessWidget {
+  const GachaCapsuleItem({
+    super.key,
+    required this.item,
+    required this.isMobile,
+    required this.isHovered,
+    required this.isSelected,
+    required this.onTap,
+    required this.onRemove,
+    required this.onHoverEnter,
+    required this.onHoverExit,
+  });
+
+  final DefaultGachaItemData item;
+  final bool isMobile;
+  final bool isHovered;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final VoidCallback onRemove;
+  final VoidCallback onHoverEnter;
+  final VoidCallback onHoverExit;
+
+  @override
+  Widget build(BuildContext context) {
+    final double? percentValue = double.tryParse(item.percentStr);
+    final bool needsEdit =
+        item.itemName.trim().isEmpty ||
+        percentValue == null ||
+        percentValue < 0.01 ||
+        percentValue > 100.0;
+
+    final double size = isMobile ? 80.0 : 96.0;
+    final double halfSize = size / 2;
+    final double iconSize = isMobile ? 42.0 : 50.0;
+    final double titleFontSize = isMobile ? 14.0 : 16.0;
+    final double percentFontSize = isMobile ? 12.0 : 14.0;
+
+    return MouseRegion(
+      onEnter: (_) => onHoverEnter(),
+      onExit: (_) => onHoverExit(),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: <Widget>[
+          InkWell(
+            onTap: onTap,
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            customBorder: const CircleBorder(),
+            child: SizedBox(
+              width: size,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Container(
+                    width: size,
+                    height: size,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: isSelected ? Colors.orange : Colors.black,
+                        width: isSelected ? 3 : 2,
+                        strokeAlign: BorderSide.strokeAlignOutside,
+                      ),
+                    ),
+                    clipBehavior: Clip.antiAlias,
+                    child: Stack(
+                      children: <Widget>[
+                        Center(
+                          child: item.imageFile != null
+                              ? Image.network(
+                                  item.imageFile!.path,
+                                  width: size,
+                                  height: size,
+                                  fit: BoxFit.cover,
+                                )
+                              : Icon(
+                                  Icons.question_mark,
+                                  size: iconSize,
+                                  color: Colors.black87,
+                                ),
+                        ),
+                        Positioned(
+                          top: 0,
+                          left: 0,
+                          right: 0,
+                          height: halfSize,
+                          child: Container(
+                            color: Colors.white.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          height: halfSize,
+                          child: Container(
+                            color: item.color.withValues(alpha: 0.7),
+                          ),
+                        ),
+                        Align(
+                          alignment: Alignment.center,
+                          child: Container(height: 1, color: Colors.black),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    item.itemName.isEmpty ? '제목 없음' : item.itemName,
+                    style: TextStyle(
+                      fontSize: titleFontSize,
+                      fontWeight: FontWeight.bold,
+                      color:
+                          item.itemName.isEmpty ? Colors.white38 : Colors.white,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                  ),
+                  Text(
+                    item.percentOpen ? '(${item.percentStr}%)' : '(미공개)',
+                    style: TextStyle(
+                      fontSize: percentFontSize,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (needsEdit)
+            Positioned(
+              top: -6,
+              left: -6,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.orange,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white, width: 2),
+                ),
+                padding: const EdgeInsets.all(4),
+                child: const Icon(
+                  Icons.priority_high,
+                  color: Colors.white,
+                  size: 16,
+                ),
+              ),
+            ),
+          if (isHovered)
+            Positioned(
+              top: -6,
+              right: -6,
+              child: GestureDetector(
+                onTap: onRemove,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.red.shade400,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: Colors.white, width: 2),
+                  ),
+                  padding: const EdgeInsets.all(4),
+                  child: const Icon(Icons.close, color: Colors.white, size: 16),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_item_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_item_edit_form.dart
@@ -89,15 +89,20 @@ class GachaItemEditForm extends StatelessWidget {
                 ),
                 child: Text(
                   label,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontFamily: 'WantedSans',
+                  ),
                 ),
               );
             }
 
-            return SafeArea(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
+            return Container(
+              color: const Color(0xFF1A1A2E),
+              child: SafeArea(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
                   Expanded(
                     child: SingleChildScrollView(
                       padding: EdgeInsets.only(
@@ -116,6 +121,7 @@ class GachaItemEditForm extends StatelessWidget {
                               const Text(
                                 '캡슐 상세 설정',
                                 style: TextStyle(
+                                  fontFamily: 'WantedSans',
                                   fontSize: 20,
                                   fontWeight: FontWeight.bold,
                                   color: Colors.white,
@@ -135,6 +141,7 @@ class GachaItemEditForm extends StatelessWidget {
                           const Text(
                             '제목',
                             style: TextStyle(
+                              fontFamily: 'WantedSans',
                               fontSize: 18,
                               fontWeight: FontWeight.bold,
                               color: Colors.white,
@@ -143,7 +150,10 @@ class GachaItemEditForm extends StatelessWidget {
                           const SizedBox(height: 8),
                           TextFormField(
                             controller: nameController,
-                            style: const TextStyle(color: Colors.white),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontFamily: 'WantedSans',
+                            ),
                             onChanged: (String val) {
                               context.read<GachaSettingBloc>().add(
                                 UpdateGachaItemName(currentItemData.id, val),
@@ -151,7 +161,13 @@ class GachaItemEditForm extends StatelessWidget {
                             },
                             decoration: InputDecoration(
                               filled: true,
-                              fillColor: Colors.white12,
+                              fillColor: Colors.white.withValues(alpha: 0.07),
+                              hintText: '제목을 입력해주세요',
+                              hintStyle: const TextStyle(
+                                color: Colors.white38,
+                                fontFamily: 'WantedSans',
+                              ),
+                              errorStyle: const TextStyle(fontFamily: 'WantedSans'),
                               suffixIcon: currentItemData.itemName.isNotEmpty
                                   ? IconButton(
                                       icon: const Icon(
@@ -217,6 +233,7 @@ class GachaItemEditForm extends StatelessWidget {
                           const Text(
                             '이미지',
                             style: TextStyle(
+                              fontFamily: 'WantedSans',
                               fontSize: 18,
                               fontWeight: FontWeight.bold,
                               color: Colors.white,
@@ -230,10 +247,10 @@ class GachaItemEditForm extends StatelessWidget {
                               child: Container(
                                 height: 120,
                                 decoration: BoxDecoration(
-                                  color: Colors.white12,
+                                  color: Colors.white.withValues(alpha: 0.07),
                                   borderRadius: BorderRadius.circular(12),
                                   border: Border.all(
-                                    color: Colors.white.withValues(alpha: 0.2),
+                                    color: Colors.white24,
                                     width: 1,
                                   ),
                                 ),
@@ -255,12 +272,10 @@ class GachaItemEditForm extends StatelessWidget {
                                     maxHeight: 500,
                                   ),
                                   decoration: BoxDecoration(
-                                    color: Colors.white12,
+                                    color: Colors.white.withValues(alpha: 0.05),
                                     borderRadius: BorderRadius.circular(12),
                                     border: Border.all(
-                                      color: Colors.white.withValues(
-                                        alpha: 0.2,
-                                      ),
+                                      color: Colors.white24,
                                       width: 1,
                                     ),
                                   ),
@@ -282,7 +297,10 @@ class GachaItemEditForm extends StatelessWidget {
                                         updateModal,
                                       ),
                                       icon: const Icon(Icons.edit, size: 16),
-                                      label: const Text('수정'),
+                                      label: const Text(
+                                        '수정',
+                                        style: TextStyle(fontFamily: 'WantedSans'),
+                                      ),
                                       style: OutlinedButton.styleFrom(
                                         foregroundColor: Colors.blue,
                                         side: const BorderSide(
@@ -300,7 +318,10 @@ class GachaItemEditForm extends StatelessWidget {
                                         );
                                       },
                                       icon: const Icon(Icons.delete, size: 16),
-                                      label: const Text('삭제'),
+                                      label: const Text(
+                                        '삭제',
+                                        style: TextStyle(fontFamily: 'WantedSans'),
+                                      ),
                                       style: OutlinedButton.styleFrom(
                                         foregroundColor: Colors.red,
                                         side: const BorderSide(
@@ -317,13 +338,15 @@ class GachaItemEditForm extends StatelessWidget {
                             '- 부적절한 제목이나 이미지는 신고 대상이 될 수 있으며, 관련 책임은 등록 주체에게 있음을 알려드립니다.',
                             style: TextStyle(
                               fontSize: 14,
-                              color: Colors.white38,
+                              color: Colors.grey,
+                              fontFamily: 'WantedSans',
                             ),
                           ),
                           const SizedBox(height: 24),
                           const Text(
                             '확률 (%)',
                             style: TextStyle(
+                              fontFamily: 'WantedSans',
                               fontSize: 18,
                               fontWeight: FontWeight.bold,
                               color: Colors.white,
@@ -335,7 +358,10 @@ class GachaItemEditForm extends StatelessWidget {
                             keyboardType: const TextInputType.numberWithOptions(
                               decimal: true,
                             ),
-                            style: const TextStyle(color: Colors.white),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontFamily: 'WantedSans',
+                            ),
                             onChanged: (String val) {
                               context.read<GachaSettingBloc>().add(
                                 UpdateGachaItemPercent(currentItemData.id, val),
@@ -343,7 +369,12 @@ class GachaItemEditForm extends StatelessWidget {
                             },
                             decoration: InputDecoration(
                               filled: true,
-                              fillColor: Colors.white12,
+                              fillColor: Colors.white.withValues(alpha: 0.07),
+                              hintText: '확률을 입력해주세요',
+                              hintStyle: const TextStyle(
+                                color: Colors.white38,
+                                fontFamily: 'WantedSans',
+                              ),
                               suffixIcon: currentItemData.percentStr.isNotEmpty
                                   ? IconButton(
                                       icon: const Icon(
@@ -403,7 +434,10 @@ class GachaItemEditForm extends StatelessWidget {
                               errorText: !isPercentValid
                                   ? '확률은 0.01% 이상 100% 이하입니다.'
                                   : null,
-                              errorStyle: const TextStyle(fontSize: 14),
+                              errorStyle: const TextStyle(
+                                fontSize: 14,
+                                fontFamily: 'WantedSans',
+                              ),
                             ),
                           ),
                           const SizedBox(height: 12),
@@ -440,6 +474,7 @@ class GachaItemEditForm extends StatelessWidget {
                                 child: Text(
                                   '확률 공개 여부',
                                   style: TextStyle(
+                                    fontFamily: 'WantedSans',
                                     fontSize: 16,
                                     color: Colors.white,
                                   ),
@@ -450,7 +485,11 @@ class GachaItemEditForm extends StatelessWidget {
                           const SizedBox(height: 16),
                           const Text(
                             '- 모든 캡슐의 확률 합이 100% 이하여야 합니다.',
-                            style: TextStyle(fontSize: 14, color: Colors.grey),
+                            style: TextStyle(
+                              fontSize: 14,
+                              color: Colors.grey,
+                              fontFamily: 'WantedSans',
+                            ),
                           ),
                           const SizedBox(height: 40),
                         ],
@@ -463,7 +502,7 @@ class GachaItemEditForm extends StatelessWidget {
                       vertical: 16,
                     ),
                     decoration: BoxDecoration(
-                      color: AppColors.darkBg,
+                      color: Colors.transparent,
                       border: Border(
                         top: BorderSide(
                           color: Colors.white.withValues(alpha: 0.1),
@@ -494,6 +533,7 @@ class GachaItemEditForm extends StatelessWidget {
                             child: const Text(
                               '삭제',
                               style: TextStyle(
+                                fontFamily: 'WantedSans',
                                 fontSize: 16,
                                 fontWeight: FontWeight.bold,
                               ),
@@ -518,6 +558,7 @@ class GachaItemEditForm extends StatelessWidget {
                             child: const Text(
                               '닫기',
                               style: TextStyle(
+                                fontFamily: 'WantedSans',
                                 fontSize: 16,
                                 fontWeight: FontWeight.bold,
                               ),
@@ -529,10 +570,11 @@ class GachaItemEditForm extends StatelessWidget {
                   ),
                 ],
               ),
-            );
-          },
-        );
-      },
-    );
-  }
+            ),
+          );
+        },
+      );
+    },
+  );
+}
 }

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_item_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_item_edit_form.dart
@@ -1,0 +1,538 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/gacha_setting/gacha_setting_bloc.dart';
+
+class GachaItemEditForm extends StatelessWidget {
+  const GachaItemEditForm({
+    super.key,
+    required this.modalContext,
+    required this.itemData,
+    required this.nameController,
+    required this.percentController,
+    required this.onPickImage,
+    required this.onDeleteItem,
+  });
+
+  final BuildContext modalContext;
+  final DefaultGachaItemData itemData;
+  final TextEditingController nameController;
+  final TextEditingController percentController;
+  final Future<void> Function(DefaultGachaItemData, VoidCallback) onPickImage;
+  final ValueChanged<int> onDeleteItem;
+
+  @override
+  Widget build(BuildContext context) {
+    return StatefulBuilder(
+      builder: (BuildContext context, StateSetter setModalState) {
+        return BlocBuilder<GachaSettingBloc, GachaSettingState>(
+          builder: (BuildContext context, GachaSettingState state) {
+            final DefaultGachaItemData currentItemData = state.uiItems
+                .firstWhere(
+                  (DefaultGachaItemData item) => item.id == itemData.id,
+                  orElse: () => itemData,
+                );
+
+            void updateModal() {
+              setModalState(() {});
+            }
+
+            final bool isTitleValid = currentItemData.itemName
+                .trim()
+                .isNotEmpty;
+            final double? percentValue = double.tryParse(
+              currentItemData.percentStr,
+            );
+            final bool isPercentValid =
+                percentValue != null &&
+                percentValue >= 0.01 &&
+                percentValue <= 100.0;
+
+            double sumWithoutCurrent = 0.0;
+            for (final DefaultGachaItemData item in state.uiItems) {
+              if (item.id != currentItemData.id) {
+                sumWithoutCurrent += item.percent;
+              }
+            }
+            double remaining = 100.0 - sumWithoutCurrent;
+            if (remaining < 0) remaining = 0.0;
+
+            String formatPercent(double percent) {
+              String s = percent.toStringAsFixed(2);
+              if (s.endsWith('.00')) return s.substring(0, s.length - 3);
+              if (s.endsWith('0')) return s.substring(0, s.length - 1);
+              return s;
+            }
+
+            final String remainingStr = formatPercent(remaining);
+
+            Widget buildQuickPercentBtn(String value, String label) {
+              return TextButton(
+                onPressed: () {
+                  final String rawValue = value.replaceAll('%', '');
+                  percentController.text = rawValue;
+                  context.read<GachaSettingBloc>().add(
+                    UpdateGachaItemPercent(currentItemData.id, rawValue),
+                  );
+                },
+                style: TextButton.styleFrom(
+                  backgroundColor: AppColors.neonPurple.withValues(alpha: 0.15),
+                  foregroundColor: AppColors.neonPurple,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: Text(
+                  label,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              );
+            }
+
+            return SafeArea(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: EdgeInsets.only(
+                        left: 32.0,
+                        right: 32.0,
+                        top: 32.0,
+                        bottom: MediaQuery.viewInsetsOf(context).bottom + 32.0,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: <Widget>[
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: <Widget>[
+                              const SizedBox(width: 24),
+                              const Text(
+                                '캡슐 상세 설정',
+                                style: TextStyle(
+                                  fontSize: 20,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                ),
+                              ),
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.close,
+                                  color: Colors.white,
+                                ),
+                                onPressed: () =>
+                                    Navigator.of(modalContext).pop(),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 32),
+                          const Text(
+                            '제목',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          TextFormField(
+                            controller: nameController,
+                            style: const TextStyle(color: Colors.white),
+                            onChanged: (String val) {
+                              context.read<GachaSettingBloc>().add(
+                                UpdateGachaItemName(currentItemData.id, val),
+                              );
+                            },
+                            decoration: InputDecoration(
+                              filled: true,
+                              fillColor: Colors.white12,
+                              suffixIcon: currentItemData.itemName.isNotEmpty
+                                  ? IconButton(
+                                      icon: const Icon(
+                                        Icons.clear,
+                                        size: 20,
+                                        color: Colors.white38,
+                                      ),
+                                      onPressed: () {
+                                        nameController.clear();
+                                        context.read<GachaSettingBloc>().add(
+                                          UpdateGachaItemName(
+                                            currentItemData.id,
+                                            '',
+                                          ),
+                                        );
+                                      },
+                                    )
+                                  : null,
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: !isTitleValid
+                                    ? const BorderSide(
+                                        color: Colors.red,
+                                        width: 1.5,
+                                      )
+                                    : const BorderSide(
+                                        color: Color(0xFF6DE1F1),
+                                        width: 1.5,
+                                      ),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: !isTitleValid
+                                    ? const BorderSide(
+                                        color: Colors.red,
+                                        width: 1.5,
+                                      )
+                                    : BorderSide(
+                                        color: Colors.white.withValues(
+                                          alpha: 0.2,
+                                        ),
+                                        width: 1,
+                                      ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: !isTitleValid
+                                    ? const BorderSide(
+                                        color: Colors.red,
+                                        width: 1.5,
+                                      )
+                                    : const BorderSide(
+                                        color: Color(0xFF6DE1F1),
+                                        width: 1.5,
+                                      ),
+                              ),
+                              errorText: !isTitleValid
+                                  ? '제목은 최소 1글자 이상이어야 합니다.'
+                                  : null,
+                            ),
+                          ),
+                          const SizedBox(height: 24),
+                          const Text(
+                            '이미지',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          if (currentItemData.imageFile == null)
+                            InkWell(
+                              onTap: () =>
+                                  onPickImage(currentItemData, updateModal),
+                              child: Container(
+                                height: 120,
+                                decoration: BoxDecoration(
+                                  color: Colors.white12,
+                                  borderRadius: BorderRadius.circular(12),
+                                  border: Border.all(
+                                    color: Colors.white.withValues(alpha: 0.2),
+                                    width: 1,
+                                  ),
+                                ),
+                                child: const Center(
+                                  child: Icon(
+                                    Icons.add_photo_alternate,
+                                    size: 40,
+                                    color: Colors.white38,
+                                  ),
+                                ),
+                              ),
+                            )
+                          else
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: <Widget>[
+                                Container(
+                                  constraints: const BoxConstraints(
+                                    maxHeight: 500,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.white12,
+                                    borderRadius: BorderRadius.circular(12),
+                                    border: Border.all(
+                                      color: Colors.white.withValues(
+                                        alpha: 0.2,
+                                      ),
+                                      width: 1,
+                                    ),
+                                  ),
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(12),
+                                    child: Image.network(
+                                      currentItemData.imageFile!.path,
+                                      fit: BoxFit.contain,
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(height: 12),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  children: <Widget>[
+                                    OutlinedButton.icon(
+                                      onPressed: () => onPickImage(
+                                        currentItemData,
+                                        updateModal,
+                                      ),
+                                      icon: const Icon(Icons.edit, size: 16),
+                                      label: const Text('수정'),
+                                      style: OutlinedButton.styleFrom(
+                                        foregroundColor: Colors.blue,
+                                        side: const BorderSide(
+                                          color: Colors.blue,
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    OutlinedButton.icon(
+                                      onPressed: () {
+                                        context.read<GachaSettingBloc>().add(
+                                          RemoveGachaItemImage(
+                                            currentItemData.id,
+                                          ),
+                                        );
+                                      },
+                                      icon: const Icon(Icons.delete, size: 16),
+                                      label: const Text('삭제'),
+                                      style: OutlinedButton.styleFrom(
+                                        foregroundColor: Colors.red,
+                                        side: const BorderSide(
+                                          color: Colors.red,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          const SizedBox(height: 24),
+                          const Text(
+                            '- 부적절한 제목이나 이미지는 신고 대상이 될 수 있으며, 관련 책임은 등록 주체에게 있음을 알려드립니다.',
+                            style: TextStyle(
+                              fontSize: 14,
+                              color: Colors.white38,
+                            ),
+                          ),
+                          const SizedBox(height: 24),
+                          const Text(
+                            '확률 (%)',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          TextFormField(
+                            controller: percentController,
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                            ),
+                            style: const TextStyle(color: Colors.white),
+                            onChanged: (String val) {
+                              context.read<GachaSettingBloc>().add(
+                                UpdateGachaItemPercent(currentItemData.id, val),
+                              );
+                            },
+                            decoration: InputDecoration(
+                              filled: true,
+                              fillColor: Colors.white12,
+                              suffixIcon: currentItemData.percentStr.isNotEmpty
+                                  ? IconButton(
+                                      icon: const Icon(
+                                        Icons.clear,
+                                        size: 20,
+                                        color: Colors.white38,
+                                      ),
+                                      onPressed: () {
+                                        percentController.clear();
+                                        context.read<GachaSettingBloc>().add(
+                                          UpdateGachaItemPercent(
+                                            currentItemData.id,
+                                            '',
+                                          ),
+                                        );
+                                      },
+                                    )
+                                  : null,
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: !isPercentValid
+                                    ? const BorderSide(
+                                        color: Colors.red,
+                                        width: 1.5,
+                                      )
+                                    : const BorderSide(
+                                        color: Color(0xFF6DE1F1),
+                                        width: 1.5,
+                                      ),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: !isPercentValid
+                                    ? const BorderSide(
+                                        color: Colors.red,
+                                        width: 1.5,
+                                      )
+                                    : BorderSide(
+                                        color: Colors.white.withValues(
+                                          alpha: 0.2,
+                                        ),
+                                        width: 1,
+                                      ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: !isPercentValid
+                                    ? const BorderSide(
+                                        color: Colors.red,
+                                        width: 1.5,
+                                      )
+                                    : const BorderSide(
+                                        color: Color(0xFF6DE1F1),
+                                        width: 1.5,
+                                      ),
+                              ),
+                              errorText: !isPercentValid
+                                  ? '확률은 0.01% 이상 100% 이하입니다.'
+                                  : null,
+                              errorStyle: const TextStyle(fontSize: 14),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: <Widget>[
+                              buildQuickPercentBtn(
+                                remainingStr,
+                                '(남은 확률) $remainingStr%',
+                              ),
+                              buildQuickPercentBtn('1', '1%'),
+                              buildQuickPercentBtn('10', '10%'),
+                              buildQuickPercentBtn('50', '50%'),
+                              buildQuickPercentBtn('100', '100%'),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          Row(
+                            children: <Widget>[
+                              Checkbox(
+                                value: currentItemData.percentOpen,
+                                onChanged: (bool? val) {
+                                  context.read<GachaSettingBloc>().add(
+                                    UpdateGachaItemPercentOpen(
+                                      currentItemData.id,
+                                      val ?? false,
+                                    ),
+                                  );
+                                },
+                                activeColor: AppColors.neonPurple,
+                              ),
+                              const Expanded(
+                                child: Text(
+                                  '확률 공개 여부',
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          const Text(
+                            '- 모든 캡슐의 확률 합이 100% 이하여야 합니다.',
+                            style: TextStyle(fontSize: 14, color: Colors.grey),
+                          ),
+                          const SizedBox(height: 40),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 32,
+                      vertical: 16,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColors.darkBg,
+                      border: Border(
+                        top: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.1),
+                        ),
+                      ),
+                    ),
+                    child: Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: () {
+                              Navigator.of(modalContext).pop();
+                              onDeleteItem(currentItemData.id);
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.transparent,
+                              foregroundColor: Colors.red.shade400,
+                              padding: const EdgeInsets.symmetric(vertical: 16),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                side: BorderSide(
+                                  color: Colors.red.shade400,
+                                  width: 1.5,
+                                ),
+                              ),
+                              elevation: 0,
+                            ),
+                            child: const Text(
+                              '삭제',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: () {
+                              Navigator.of(modalContext).pop();
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.neonPurple,
+                              foregroundColor: Colors.white,
+                              padding: const EdgeInsets.symmetric(vertical: 16),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              elevation: 0,
+                            ),
+                            child: const Text(
+                              '닫기',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_items_section.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_items_section.dart
@@ -1,0 +1,299 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../../../application/gacha_setting/gacha_setting_bloc.dart';
+import 'gacha_capsule_item.dart';
+
+class GachaItemsSection extends StatelessWidget {
+  const GachaItemsSection({
+    super.key,
+    required this.totalPercent,
+    required this.isMobile,
+    required this.uiItems,
+    required this.hoveredItemId,
+    required this.selectedItemId,
+    required this.onAddItem,
+    required this.onRemoveAllItems,
+    required this.onTapItem,
+    required this.onRemoveItem,
+    required this.onHoverEnter,
+    required this.onHoverExit,
+  });
+
+  final double totalPercent;
+  final bool isMobile;
+  final List<DefaultGachaItemData> uiItems;
+  final int? hoveredItemId;
+  final int? selectedItemId;
+  final VoidCallback onAddItem;
+  final VoidCallback onRemoveAllItems;
+  final ValueChanged<DefaultGachaItemData> onTapItem;
+  final ValueChanged<int> onRemoveItem;
+  final ValueChanged<int> onHoverEnter;
+  final VoidCallback onHoverExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        if (isMobile) ...<Widget>[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              ElevatedButton.icon(
+                onPressed: onAddItem,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blue,
+                  foregroundColor: Colors.white,
+                  elevation: 0,
+                ),
+                icon: const Icon(Icons.add, size: 18),
+                label: const Text('추가'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton.icon(
+                onPressed: onRemoveAllItems,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red.shade400,
+                  foregroundColor: Colors.white,
+                  elevation: 0,
+                ),
+                icon: const Icon(Icons.delete_outline, size: 18),
+                label: const Text('모두 제거'),
+              ),
+            ],
+          ),
+        ] else ...<Widget>[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Flexible(
+                child: RichText(
+                  overflow: TextOverflow.ellipsis,
+                  text: TextSpan(
+                    style: const TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      fontFamily: 'PFStardust',
+                      color: Colors.white,
+                    ),
+                    children: <InlineSpan>[
+                      const TextSpan(text: '전체 확률 : '),
+                      TextSpan(
+                        text: '${totalPercent.toStringAsFixed(2)}%',
+                        style: TextStyle(
+                          color:
+                              (totalPercent >= 99.99 && totalPercent <= 100.01)
+                              ? Colors.green
+                              : Colors.red,
+                        ),
+                      ),
+                      const TextSpan(text: ' / 100.0%'),
+                      const TextSpan(text: ' [ '),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        child: Image.asset(
+                          'assets/images/gacha.png',
+                          width: 28,
+                          height: 28,
+                        ),
+                      ),
+                      const TextSpan(
+                        text: ' : ',
+                        style: TextStyle(color: Colors.white),
+                      ),
+                      TextSpan(
+                        text: '${uiItems.length}개 ]',
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  ElevatedButton.icon(
+                    onPressed: onAddItem,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.blue,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                    ),
+                    icon: const Icon(Icons.add, size: 18),
+                    label: const Text('추가'),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton.icon(
+                    onPressed: onRemoveAllItems,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red.shade400,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                    ),
+                    icon: const Icon(Icons.delete_outline, size: 18),
+                    label: const Text('모두 제거'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+        const SizedBox(height: 24),
+        if (isMobile)
+          _CapsuleListContainer(
+            isMobile: true,
+            uiItems: uiItems,
+            hoveredItemId: hoveredItemId,
+            selectedItemId: selectedItemId,
+            onAddItem: onAddItem,
+            onTapItem: onTapItem,
+            onRemoveItem: onRemoveItem,
+            onHoverEnter: onHoverEnter,
+            onHoverExit: onHoverExit,
+          )
+        else
+          Expanded(
+            child: SingleChildScrollView(
+              child: _CapsuleListContainer(
+                isMobile: false,
+                uiItems: uiItems,
+                hoveredItemId: hoveredItemId,
+                selectedItemId: selectedItemId,
+                onAddItem: onAddItem,
+                onTapItem: onTapItem,
+                onRemoveItem: onRemoveItem,
+                onHoverEnter: onHoverEnter,
+                onHoverExit: onHoverExit,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CapsuleListContainer extends StatelessWidget {
+  const _CapsuleListContainer({
+    required this.isMobile,
+    required this.uiItems,
+    required this.hoveredItemId,
+    required this.selectedItemId,
+    required this.onAddItem,
+    required this.onTapItem,
+    required this.onRemoveItem,
+    required this.onHoverEnter,
+    required this.onHoverExit,
+  });
+
+  final bool isMobile;
+  final List<DefaultGachaItemData> uiItems;
+  final int? hoveredItemId;
+  final int? selectedItemId;
+  final VoidCallback onAddItem;
+  final ValueChanged<DefaultGachaItemData> onTapItem;
+  final ValueChanged<int> onRemoveItem;
+  final ValueChanged<int> onHoverEnter;
+  final VoidCallback onHoverExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.05),
+        border: Border.all(
+          color: Colors.white.withValues(alpha: 0.1),
+          width: 1,
+        ),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Wrap(
+        spacing: 32,
+        runSpacing: 32,
+        children: <Widget>[
+          for (int i = 0; i < uiItems.length; i++)
+            GachaCapsuleItem(
+              item: uiItems[i],
+              isMobile: isMobile,
+              isHovered: hoveredItemId == uiItems[i].id,
+              isSelected: selectedItemId == uiItems[i].id,
+              onTap: () => onTapItem(uiItems[i]),
+              onRemove: () => onRemoveItem(uiItems[i].id),
+              onHoverEnter: () => onHoverEnter(uiItems[i].id),
+              onHoverExit: onHoverExit,
+            ),
+          InkWell(
+            onTap: onAddItem,
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            borderRadius: BorderRadius.circular(50),
+            child: Container(
+              width: isMobile ? 80 : 96,
+              height: isMobile ? 80 : 96,
+              decoration: const BoxDecoration(shape: BoxShape.circle),
+              child: Stack(
+                children: <Widget>[
+                  Positioned.fill(
+                    child: CustomPaint(
+                      painter: _DashedCirclePainter(
+                        color: Colors.white38,
+                        strokeWidth: 1.5,
+                      ),
+                    ),
+                  ),
+                  const Center(
+                    child: Icon(Icons.add, color: Colors.white38, size: 32),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DashedCirclePainter extends CustomPainter {
+  _DashedCirclePainter({required this.color, required this.strokeWidth});
+
+  final Color color;
+  final double strokeWidth;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke;
+
+    final double radius = size.width / 2;
+    final double perimeter = 2 * pi * radius;
+    const double dashLength = 6.0;
+    const double dashSpace = 4.0;
+
+    final int dashCount = (perimeter / (dashLength + dashSpace)).floor();
+    final double sweepAngle = (dashLength / perimeter) * 360 * (pi / 180);
+    final double spaceAngle = (dashSpace / perimeter) * 360 * (pi / 180);
+
+    double currentAngle = 0;
+    for (int i = 0; i < dashCount; i++) {
+      canvas.drawArc(
+        Rect.fromCircle(center: Offset(radius, radius), radius: radius),
+        currentAngle,
+        sweepAngle,
+        false,
+        paint,
+      );
+      currentAngle += sweepAngle + spaceAngle;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_items_section.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_items_section.dart
@@ -143,22 +143,11 @@ class GachaItemsSection extends StatelessWidget {
         ],
         const SizedBox(height: 24),
         if (isMobile)
-          _CapsuleListContainer(
-            isMobile: true,
-            uiItems: uiItems,
-            hoveredItemId: hoveredItemId,
-            selectedItemId: selectedItemId,
-            onAddItem: onAddItem,
-            onTapItem: onTapItem,
-            onRemoveItem: onRemoveItem,
-            onHoverEnter: onHoverEnter,
-            onHoverExit: onHoverExit,
-          )
-        else
-          Expanded(
-            child: SingleChildScrollView(
-              child: _CapsuleListContainer(
-                isMobile: false,
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              _CapsuleListContainer(
+                isMobile: true,
                 uiItems: uiItems,
                 hoveredItemId: hoveredItemId,
                 selectedItemId: selectedItemId,
@@ -167,6 +156,45 @@ class GachaItemsSection extends StatelessWidget {
                 onRemoveItem: onRemoveItem,
                 onHoverEnter: onHoverEnter,
                 onHoverExit: onHoverExit,
+              ),
+              const Padding(
+                padding: EdgeInsets.only(top: 12),
+                child: Center(
+                  child: Text(
+                    '캡슐은 최대 10개까지만 추가가 가능합니다',
+                    style: TextStyle(color: Colors.white54, fontSize: 13),
+                  ),
+                ),
+              ),
+            ],
+          )
+        else
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  _CapsuleListContainer(
+                    isMobile: false,
+                    uiItems: uiItems,
+                    hoveredItemId: hoveredItemId,
+                    selectedItemId: selectedItemId,
+                    onAddItem: onAddItem,
+                    onTapItem: onTapItem,
+                    onRemoveItem: onRemoveItem,
+                    onHoverEnter: onHoverEnter,
+                    onHoverExit: onHoverExit,
+                  ),
+                  const Padding(
+                    padding: EdgeInsets.only(top: 12),
+                    child: Center(
+                      child: Text(
+                        '캡슐은 최대 10개까지만 추가가 가능합니다',
+                        style: TextStyle(color: Colors.white54, fontSize: 13),
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_items_section.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_items_section.dart
@@ -42,17 +42,19 @@ class GachaItemsSection extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: <Widget>[
-              ElevatedButton.icon(
-                onPressed: onAddItem,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.blue,
-                  foregroundColor: Colors.white,
-                  elevation: 0,
+              if (uiItems.length < 10) ...<Widget>[
+                ElevatedButton.icon(
+                  onPressed: onAddItem,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.blue,
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                  ),
+                  icon: const Icon(Icons.add, size: 18),
+                  label: const Text('추가'),
                 ),
-                icon: const Icon(Icons.add, size: 18),
-                label: const Text('추가'),
-              ),
-              const SizedBox(width: 8),
+                const SizedBox(width: 8),
+              ],
               ElevatedButton.icon(
                 onPressed: onRemoveAllItems,
                 style: ElevatedButton.styleFrom(
@@ -115,17 +117,19 @@ class GachaItemsSection extends StatelessWidget {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  ElevatedButton.icon(
-                    onPressed: onAddItem,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.blue,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
+                  if (uiItems.length < 10) ...<Widget>[
+                    ElevatedButton.icon(
+                      onPressed: onAddItem,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.blue,
+                        foregroundColor: Colors.white,
+                        elevation: 0,
+                      ),
+                      icon: const Icon(Icons.add, size: 18),
+                      label: const Text('추가'),
                     ),
-                    icon: const Icon(Icons.add, size: 18),
-                    label: const Text('추가'),
-                  ),
-                  const SizedBox(width: 8),
+                    const SizedBox(width: 8),
+                  ],
                   ElevatedButton.icon(
                     onPressed: onRemoveAllItems,
                     style: ElevatedButton.styleFrom(
@@ -254,33 +258,34 @@ class _CapsuleListContainer extends StatelessWidget {
               onHoverEnter: () => onHoverEnter(uiItems[i].id),
               onHoverExit: onHoverExit,
             ),
-          InkWell(
-            onTap: onAddItem,
-            splashColor: Colors.transparent,
-            highlightColor: Colors.transparent,
-            hoverColor: Colors.transparent,
-            borderRadius: BorderRadius.circular(50),
-            child: Container(
-              width: isMobile ? 80 : 96,
-              height: isMobile ? 80 : 96,
-              decoration: const BoxDecoration(shape: BoxShape.circle),
-              child: Stack(
-                children: <Widget>[
-                  Positioned.fill(
-                    child: CustomPaint(
-                      painter: _DashedCirclePainter(
-                        color: Colors.white38,
-                        strokeWidth: 1.5,
+          if (uiItems.length < 10)
+            InkWell(
+              onTap: onAddItem,
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              hoverColor: Colors.transparent,
+              borderRadius: BorderRadius.circular(50),
+              child: Container(
+                width: isMobile ? 80 : 96,
+                height: isMobile ? 80 : 96,
+                decoration: const BoxDecoration(shape: BoxShape.circle),
+                child: Stack(
+                  children: <Widget>[
+                    Positioned.fill(
+                      child: CustomPaint(
+                        painter: _DashedCirclePainter(
+                          color: Colors.white38,
+                          strokeWidth: 1.5,
+                        ),
                       ),
                     ),
-                  ),
-                  const Center(
-                    child: Icon(Icons.add, color: Colors.white38, size: 32),
-                  ),
-                ],
+                    const Center(
+                      child: Icon(Icons.add, color: Colors.white38, size: 32),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
         ],
       ),
     );

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_mobile_bottom_bar.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_mobile_bottom_bar.dart
@@ -126,6 +126,7 @@ class GachaMobileBottomBar extends StatelessWidget {
                         backgroundColor: canComplete
                             ? const Color(0xFF6DE1F1)
                             : Colors.grey.shade300,
+                        disabledBackgroundColor: Colors.grey.shade800,
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(16),
                         ),

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_mobile_bottom_bar.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_mobile_bottom_bar.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+
+class GachaMobileBottomBar extends StatelessWidget {
+  const GachaMobileBottomBar({
+    super.key,
+    required this.totalPercent,
+    required this.itemCount,
+    required this.canComplete,
+    required this.onComplete,
+    required this.onShowSettings,
+  });
+
+  final double totalPercent;
+  final int itemCount;
+  final bool canComplete;
+  final VoidCallback onComplete;
+  final VoidCallback onShowSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.07),
+          border: const Border(top: BorderSide(color: Colors.white12)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const Tooltip(
+                  triggerMode: TooltipTriggerMode.tap,
+                  showDuration: Duration(seconds: 4),
+                  margin: EdgeInsets.symmetric(horizontal: 24),
+                  padding: EdgeInsets.all(12),
+                  textStyle: TextStyle(
+                    color: Colors.white,
+                    fontSize: 13,
+                    height: 1.5,
+                  ),
+                  message:
+                      '⚠️ 포장 완료 조건\n'
+                      '• 캡슐 최소 1개 이상 생성\n'
+                      '• 상단 닉네임 및 서브타이틀 입력\n'
+                      '• 뽑기 가능 횟수 최소 1 이상\n'
+                      '• 미완성 캡슐 없음\n'
+                      '• 전체 확률 100% 충족',
+                  child: Padding(
+                    padding: EdgeInsets.only(right: 8),
+                    child: Icon(
+                      Icons.info_outline,
+                      size: 20,
+                      color: Colors.white38,
+                    ),
+                  ),
+                ),
+                RichText(
+                  text: TextSpan(
+                    style: const TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      fontFamily: 'PFStardust',
+                      color: Colors.white,
+                    ),
+                    children: <InlineSpan>[
+                      const TextSpan(text: '전체 확률 : '),
+                      TextSpan(
+                        text: '${totalPercent.toStringAsFixed(2)}%',
+                        style: TextStyle(
+                          color:
+                              (totalPercent >= 99.99 && totalPercent <= 100.01)
+                              ? Colors.green
+                              : Colors.red,
+                        ),
+                      ),
+                      const TextSpan(text: ' / 100.00%'),
+                      const TextSpan(text: ' [ '),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        child: Image.asset(
+                          'assets/images/gacha.png',
+                          width: 28,
+                          height: 28,
+                        ),
+                      ),
+                      TextSpan(
+                        text: ' : $itemCount개 ]',
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: <Widget>[
+                InkWell(
+                  onTap: onShowSettings,
+                  borderRadius: BorderRadius.circular(16),
+                  child: Container(
+                    width: 56,
+                    height: 56,
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.07),
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: Colors.white.withValues(alpha: 0.15),
+                        width: 2,
+                      ),
+                    ),
+                    child: const Icon(Icons.settings, color: Colors.white60),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: SizedBox(
+                    height: 56,
+                    child: ElevatedButton(
+                      onPressed: canComplete ? onComplete : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: canComplete
+                            ? const Color(0xFF6DE1F1)
+                            : Colors.grey.shade300,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        elevation: 0,
+                      ),
+                      child: Text(
+                        '포장 완료',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color:
+                              canComplete ? Colors.black : Colors.grey.shade500,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_settings_panel.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_settings_panel.dart
@@ -236,6 +236,7 @@ class GachaSettingsPanel extends StatelessWidget {
               style: ElevatedButton.styleFrom(
                 backgroundColor:
                     canComplete ? const Color(0xFF6DE1F1) : Colors.grey.shade300,
+                disabledBackgroundColor: Colors.grey.shade800,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
                 ),

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_settings_panel.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_settings_panel.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../application/gacha_setting/gacha_setting_bloc.dart';
+
+class GachaSettingsPanel extends StatelessWidget {
+  const GachaSettingsPanel({
+    super.key,
+    required this.isMobile,
+    required this.playCountController,
+    required this.canComplete,
+    required this.onComplete,
+  });
+
+  final bool isMobile;
+  final TextEditingController playCountController;
+  final bool canComplete;
+  final VoidCallback onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (!isMobile) const SizedBox(height: 24),
+        Row(
+          children: <Widget>[
+            const Icon(Icons.casino, size: 20, color: Colors.white),
+            const SizedBox(width: 8),
+            const Expanded(
+              child: Text(
+                '뽑기 가능 횟수',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+              ),
+            ),
+            const Spacer(),
+            SizedBox(
+              width: 70,
+              child: TextFormField(
+                controller: playCountController,
+                textAlign: TextAlign.right,
+                keyboardType: TextInputType.number,
+                inputFormatters: <TextInputFormatter>[
+                  FilteringTextInputFormatter.digitsOnly,
+                ],
+                style: const TextStyle(color: Colors.white),
+                decoration: InputDecoration(
+                  filled: true,
+                  fillColor: Colors.white12,
+                  isDense: true,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: const BorderSide(
+                      color: Color(0xFF6DE1F1),
+                      width: 1.5,
+                    ),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: BorderSide(
+                      color: Colors.white.withValues(alpha: 0.2),
+                      width: 1,
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    borderSide: const BorderSide(
+                      color: Color(0xFF6DE1F1),
+                      width: 1.5,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            const Text(
+              '회',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        BlocBuilder<GachaSettingBloc, GachaSettingState>(
+          builder: (BuildContext context, GachaSettingState state) => Text(
+            '최대 ${state.uiItems.length}회 설정 가능 (캡슐 개수 기준)',
+            style: const TextStyle(fontSize: 12, color: Colors.white38),
+            textAlign: TextAlign.end,
+          ),
+        ),
+        const SizedBox(height: 40),
+        const Row(
+          children: <Widget>[
+            Icon(Icons.music_note, size: 20, color: Colors.white),
+            SizedBox(width: 8),
+            Text(
+              'BGM 설정',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: BlocBuilder<GachaSettingBloc, GachaSettingState>(
+                  builder: (BuildContext context, GachaSettingState state) =>
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        decoration: BoxDecoration(
+                          color: Colors.white12,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: DropdownButtonHideUnderline(
+                          child: DropdownButton<String>(
+                            dropdownColor: const Color(0xFF1A1A1A),
+                            style: const TextStyle(color: Colors.white),
+                            iconEnabledColor: Colors.white38,
+                            value: state.selectedBgm,
+                            isExpanded: true,
+                            onChanged: (String? val) {
+                              if (val != null) {
+                                context.read<GachaSettingBloc>().add(
+                                  UpdateBgm(val),
+                                );
+                              }
+                            },
+                            items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
+                                .map(
+                                  (String value) => DropdownMenuItem<String>(
+                                    value: value,
+                                    child: Text(
+                                      value,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                        ),
+                      ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Colors.white12,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Icon(Icons.play_arrow, color: Colors.white38),
+              ),
+            ],
+          ),
+        ),
+        if (!isMobile) ...<Widget>[
+          const Spacer(),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.06),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.1),
+                width: 1,
+              ),
+            ),
+            child: const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  '⚠️ 포장 완료 조건',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 13,
+                    color: Colors.deepOrange,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  '• 캡슐 최소 1개 이상 생성',
+                  style: TextStyle(fontSize: 16, color: Colors.white54),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+                Text(
+                  '• 상단 이름 및 서브타이틀 입력',
+                  style: TextStyle(fontSize: 16, color: Colors.white54),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+                Text(
+                  '• 뽑기 가능 횟수 최소 1회 이상',
+                  style: TextStyle(fontSize: 16, color: Colors.white54),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+                Text(
+                  '• 미완성 캡슐 없음',
+                  style: TextStyle(fontSize: 16, color: Colors.white54),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+                Text(
+                  '• 전체 확률 100% 충족',
+                  style: TextStyle(fontSize: 16, color: Colors.white54),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            height: 60,
+            child: ElevatedButton(
+              onPressed: canComplete ? onComplete : null,
+              style: ElevatedButton.styleFrom(
+                backgroundColor:
+                    canComplete ? const Color(0xFF6DE1F1) : Colors.grey.shade300,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                elevation: 0,
+              ),
+              child: Text(
+                '포장 완료',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: canComplete ? Colors.black : Colors.grey.shade500,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gacha/gacha_title_bar.dart
+++ b/lib/features/addgift/presentation/widgets/gacha/gacha_title_bar.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+class GachaTitleBar extends StatelessWidget {
+  const GachaTitleBar({
+    super.key,
+    required this.userNameController,
+    required this.subTitleController,
+    this.suffixLabel = '캡슐 뽑기',
+  });
+
+  final TextEditingController userNameController;
+  final TextEditingController subTitleController;
+  final String suffixLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 100,
+          child: TextFormField(
+            controller: userNameController,
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              hintText: '닉네임',
+              hintStyle: const TextStyle(color: Colors.white38),
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 12,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(
+                  color: Color(0xFF6DE1F1),
+                  width: 1.5,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        const Text(
+          '님의',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 120,
+          child: TextFormField(
+            controller: subTitleController,
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              hintText: '서브 타이틀',
+              hintStyle: const TextStyle(color: Colors.white38),
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 12,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(
+                  color: Color(0xFF6DE1F1),
+                  width: 1.5,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          suffixLabel,
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gift_delivery/gift_delivery_main_text.dart
+++ b/lib/features/addgift/presentation/widgets/gift_delivery/gift_delivery_main_text.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class GiftDeliveryMainText extends StatelessWidget {
+  const GiftDeliveryMainText({super.key, required this.alignment});
+
+  final TextAlign alignment;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '친구에게 전달할 방식을\n선택해주세요 !',
+      textAlign: alignment,
+      style: const TextStyle(
+        fontFamily: 'PFStardustS',
+        fontSize: 28,
+        color: Colors.white,
+        height: 1.5,
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gift_delivery/gift_delivery_option_card.dart
+++ b/lib/features/addgift/presentation/widgets/gift_delivery/gift_delivery_option_card.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class GiftDeliveryOptionCard extends StatelessWidget {
+  const GiftDeliveryOptionCard({
+    super.key,
+    required this.title,
+    required this.iconPath,
+    required this.accent,
+    required this.onTap,
+  });
+
+  final String title;
+  final String iconPath;
+  final Color accent;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          decoration: BoxDecoration(
+            color: accent.withValues(alpha: 0.07),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: accent.withValues(alpha: 0.4),
+              width: 1.5,
+            ),
+          ),
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Expanded(
+                child: Center(
+                  child: Image.asset(iconPath, fit: BoxFit.contain),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontFamily: 'WantedSans',
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: accent,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/gift_delivery/gift_delivery_options_grid.dart
+++ b/lib/features/addgift/presentation/widgets/gift_delivery/gift_delivery_options_grid.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import 'gift_delivery_option_card.dart';
+
+class GiftDeliveryOptionsGrid extends StatelessWidget {
+  const GiftDeliveryOptionsGrid({
+    super.key,
+    required this.isDesktop,
+    required this.onTapOption,
+  });
+
+  final bool isDesktop;
+  final ValueChanged<String> onTapOption;
+
+  @override
+  Widget build(BuildContext context) {
+    final int crossAxisCount = isDesktop ? 3 : 2;
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
+        mainAxisSpacing: 20,
+        crossAxisSpacing: 20,
+        childAspectRatio: 0.8,
+      ),
+      itemCount: _options.length,
+      itemBuilder: (BuildContext context, int index) {
+        final _GiftDeliveryOptionData option = _options[index];
+        return GiftDeliveryOptionCard(
+          title: option.title,
+          iconPath: option.iconPath,
+          accent: option.accent,
+          onTap: () => onTapOption(option.title),
+        );
+      },
+    );
+  }
+}
+
+class _GiftDeliveryOptionData {
+  const _GiftDeliveryOptionData({
+    required this.title,
+    required this.iconPath,
+    required this.accent,
+  });
+
+  final String title;
+  final String iconPath;
+  final Color accent;
+}
+
+const List<_GiftDeliveryOptionData> _options = <_GiftDeliveryOptionData>[
+  _GiftDeliveryOptionData(
+    title: '캡슐 뽑기',
+    iconPath: 'assets/images/gacha_machine.png',
+    accent: AppColors.neonPurple,
+  ),
+  _GiftDeliveryOptionData(
+    title: '문제 맞추기',
+    iconPath: 'assets/images/quiz_character.png',
+    accent: AppColors.neonBlue,
+  ),
+  _GiftDeliveryOptionData(
+    title: '바로 오픈',
+    iconPath: 'assets/images/open_gift_box.png',
+    accent: AppColors.pixelPurple,
+  ),
+];

--- a/lib/features/addgift/presentation/widgets/memory_decision/memory_decision_buttons_column.dart
+++ b/lib/features/addgift/presentation/widgets/memory_decision/memory_decision_buttons_column.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import 'memory_decision_selection_button.dart';
+
+class MemoryDecisionButtonsColumn extends StatelessWidget {
+  const MemoryDecisionButtonsColumn({
+    super.key,
+    required this.onSelectShareMemory,
+    required this.onSelectDirectOpen,
+  });
+
+  final VoidCallback onSelectShareMemory;
+  final VoidCallback onSelectDirectOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        MemoryDecisionSelectionButton(
+          title: '네,',
+          subtitle: '저는 친구와 함께 추억을 공유하고 싶어요!',
+          icon: Icons.photo_library_rounded,
+          accentColor: AppColors.neonPurple,
+          onPressed: onSelectShareMemory,
+        ),
+        const SizedBox(height: 16),
+        MemoryDecisionSelectionButton(
+          title: '아니요,',
+          subtitle: '저는 바로 선물을 공개할거에요.',
+          icon: Icons.card_giftcard_rounded,
+          accentColor: AppColors.neonBlue,
+          onPressed: onSelectDirectOpen,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_decision/memory_decision_main_text.dart
+++ b/lib/features/addgift/presentation/widgets/memory_decision/memory_decision_main_text.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class MemoryDecisionMainText extends StatelessWidget {
+  const MemoryDecisionMainText({super.key, required this.alignment});
+
+  final TextAlign alignment;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '선물을 공개하기 전,\n친구와 추억을 공유할까요?',
+      textAlign: alignment,
+      style: const TextStyle(
+        fontFamily: 'PFStardustS',
+        fontSize: 28,
+        color: Colors.white,
+        height: 1.5,
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_decision/memory_decision_selection_button.dart
+++ b/lib/features/addgift/presentation/widgets/memory_decision/memory_decision_selection_button.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+class MemoryDecisionSelectionButton extends StatelessWidget {
+  const MemoryDecisionSelectionButton({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.accentColor,
+    required this.onPressed,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final Color accentColor;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(20.0),
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 28.0, horizontal: 16.0),
+          decoration: BoxDecoration(
+            color: accentColor.withValues(alpha: 0.07),
+            border: Border.all(
+              color: accentColor.withValues(alpha: 0.5),
+              width: 1.5,
+            ),
+            borderRadius: BorderRadius.circular(20.0),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(icon, size: 48, color: accentColor),
+              const SizedBox(height: 20),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontFamily: 'PFStardustS',
+                  fontSize: 22,
+                  color: accentColor,
+                  height: 1.3,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                subtitle,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontFamily: 'WantedSans',
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  height: 1.5,
+                  color: Colors.white60,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_desktop_card.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_desktop_card.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+
+class MemoryDesktopCard extends StatelessWidget {
+  const MemoryDesktopCard({
+    required super.key,
+    required this.index,
+    required this.itemData,
+    required this.isIncomplete,
+    required this.isSelected,
+    required this.isHovered,
+    required this.onTap,
+    required this.onRemove,
+    required this.onHoverEnter,
+    required this.onHoverExit,
+  });
+
+  final int index;
+  final MemoryGalleryItemData itemData;
+  final bool isIncomplete;
+  final bool isSelected;
+  final bool isHovered;
+  final VoidCallback onTap;
+  final VoidCallback onRemove;
+  final VoidCallback onHoverEnter;
+  final VoidCallback onHoverExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) => onHoverEnter(),
+      onExit: (_) => onHoverExit(),
+      child: ReorderableDragStartListener(
+        index: index,
+        child: Stack(
+            clipBehavior: Clip.none,
+            children: <Widget>[
+              Positioned.fill(
+                child: Material(
+                  color: Colors.white.withValues(alpha: 0.05),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16.0),
+                    side: BorderSide(
+                      color: isSelected ? AppColors.neonPurple : Colors.white24,
+                      width: isSelected ? 2.5 : 1.0,
+                    ),
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    onTap: onTap,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20.0,
+                        vertical: 24.0,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: <Widget>[
+                          Expanded(
+                            child: Container(
+                              width: double.infinity,
+                              clipBehavior: Clip.antiAlias,
+                              decoration: BoxDecoration(
+                                color: Colors.white.withValues(alpha: 0.08),
+                                borderRadius: BorderRadius.circular(12.0),
+                              ),
+                              child: itemData.imageFile != null
+                                  ? Image.network(
+                                      itemData.imageFile!.path,
+                                      fit: BoxFit.cover,
+                                    )
+                                  : Icon(
+                                      Icons.photo,
+                                      size: 40,
+                                      color: Colors.grey.shade300,
+                                    ),
+                            ),
+                          ),
+                          const SizedBox(height: 20),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              Text(
+                                itemData.title.isEmpty
+                                    ? '제목 없음'
+                                    : itemData.title,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontFamily: 'WantedSans',
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                  color: itemData.title.isEmpty
+                                      ? Colors.white38
+                                      : Colors.white,
+                                ),
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                itemData.description.isEmpty
+                                    ? '설명 없음'
+                                    : itemData.description,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontFamily: 'WantedSans',
+                                  fontSize: 14,
+                                  height: 1.5,
+                                  color: itemData.description.isEmpty
+                                      ? Colors.white38
+                                      : Colors.white70,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              if (isIncomplete)
+                Positioned(
+                  top: -6,
+                  left: -6,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.orange,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 2),
+                    ),
+                    padding: const EdgeInsets.all(4),
+                    child: const Icon(
+                      Icons.priority_high,
+                      color: Colors.white,
+                      size: 16,
+                    ),
+                  ),
+                ),
+              if (isHovered)
+                Positioned(
+                  top: -6,
+                  right: -6,
+                  child: GestureDetector(
+                    onTap: onRemove,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: Colors.red.shade400,
+                        shape: BoxShape.circle,
+                        border: Border.all(color: Colors.white, width: 2),
+                      ),
+                      padding: const EdgeInsets.all(4),
+                      child: const Icon(
+                        Icons.close,
+                        color: Colors.white,
+                        size: 16,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_edit_form.dart
@@ -1,0 +1,370 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+
+class MemoryEditForm extends StatelessWidget {
+  const MemoryEditForm({
+    super.key,
+    required this.itemId,
+    required this.onPickImage,
+  });
+
+  final int itemId;
+  final VoidCallback onPickImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<MemoryGallerySettingBloc, MemoryGallerySettingState>(
+      builder: (BuildContext context, MemoryGallerySettingState state) {
+        final MemoryGalleryItemData? itemData = state.uiItems
+            .where((MemoryGalleryItemData item) => item.id == itemId)
+            .firstOrNull;
+
+        if (itemData == null) return const SizedBox.shrink();
+
+        final bool isTitleValid = itemData.title.trim().isNotEmpty;
+        final bool isDescriptionValid = itemData.description.trim().isNotEmpty;
+        final bool hasImage = itemData.imageFile != null;
+
+        return SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.only(
+                    left: 32.0,
+                    right: 32.0,
+                    top: 32.0,
+                    bottom: MediaQuery.viewInsetsOf(context).bottom + 32.0,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          const SizedBox(width: 24),
+                          const Text(
+                            '추억 상세 설정',
+                            style: TextStyle(
+                              fontFamily: 'WantedSans',
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(
+                              Icons.close,
+                              color: Colors.white70,
+                            ),
+                            onPressed: () => Navigator.of(context).pop(),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 32),
+                      const Text(
+                        '제목',
+                        style: TextStyle(
+                          fontFamily: 'WantedSans',
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TextFormField(
+                        key: ValueKey<String>('title_$itemId'),
+                        initialValue: itemData.title,
+                        style: const TextStyle(color: Colors.white),
+                        onChanged: (String val) {
+                          context.read<MemoryGallerySettingBloc>().add(
+                            UpdateMemoryItemTitle(itemId, val),
+                          );
+                        },
+                        decoration: InputDecoration(
+                          filled: true,
+                          fillColor: Colors.white.withValues(alpha: 0.07),
+                          hintText: '제목을 입력해주세요',
+                          hintStyle: const TextStyle(color: Colors.white38),
+                          suffixIcon: itemData.title.isNotEmpty
+                              ? IconButton(
+                                  icon: const Icon(Icons.clear, size: 20),
+                                  onPressed: () {
+                                    context
+                                        .read<MemoryGallerySettingBloc>()
+                                        .add(
+                                          UpdateMemoryItemTitle(itemId, ''),
+                                        );
+                                  },
+                                )
+                              : null,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: isTitleValid
+                                  ? const Color(0xFF6DE1F1)
+                                  : Colors.red,
+                              width: 1.5,
+                            ),
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: isTitleValid ? Colors.white24 : Colors.red,
+                              width: isTitleValid ? 1.0 : 1.5,
+                            ),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: isTitleValid
+                                  ? AppColors.neonPurple
+                                  : Colors.red,
+                              width: 1.5,
+                            ),
+                          ),
+                          errorText: !isTitleValid
+                              ? '제목은 최소 1글자 이상이어야 합니다.'
+                              : null,
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      const Text(
+                        '이미지',
+                        style: TextStyle(
+                          fontFamily: 'WantedSans',
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      if (!hasImage)
+                        InkWell(
+                          onTap: onPickImage,
+                          child: Container(
+                            height: 120,
+                            decoration: BoxDecoration(
+                              color: Colors.white.withValues(alpha: 0.07),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color: Colors.white24,
+                                width: 1,
+                              ),
+                            ),
+                            child: const Center(
+                              child: Icon(
+                                Icons.add_photo_alternate,
+                                size: 40,
+                                color: Colors.white38,
+                              ),
+                            ),
+                          ),
+                        )
+                      else
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: <Widget>[
+                            Container(
+                              constraints:
+                                  const BoxConstraints(maxHeight: 500),
+                              decoration: BoxDecoration(
+                                color: Colors.white.withValues(alpha: 0.05),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: Colors.white24,
+                                  width: 1,
+                                ),
+                              ),
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(12),
+                                child: Image.network(
+                                  itemData.imageFile!.path,
+                                  fit: BoxFit.contain,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              children: <Widget>[
+                                OutlinedButton.icon(
+                                  onPressed: onPickImage,
+                                  icon: const Icon(Icons.edit, size: 16),
+                                  label: const Text('수정'),
+                                  style: OutlinedButton.styleFrom(
+                                    foregroundColor: AppColors.neonBlue,
+                                    side: const BorderSide(
+                                      color: AppColors.neonBlue,
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                OutlinedButton.icon(
+                                  onPressed: () {
+                                    context
+                                        .read<MemoryGallerySettingBloc>()
+                                        .add(RemoveMemoryItemImage(itemId));
+                                  },
+                                  icon: const Icon(Icons.delete, size: 16),
+                                  label: const Text('삭제'),
+                                  style: OutlinedButton.styleFrom(
+                                    foregroundColor: Colors.redAccent,
+                                    side: const BorderSide(
+                                      color: Colors.redAccent,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      const SizedBox(height: 8),
+                      const Text(
+                        '- 부적절한 제목이나 이미지는 신고 대상이 될 수 있으며, 관련 책임은 등록 주체에게 있음을 알려드립니다.',
+                        style: TextStyle(fontSize: 14, color: Colors.grey),
+                      ),
+                      const SizedBox(height: 24),
+                      const Text(
+                        '설명',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TextFormField(
+                        key: ValueKey<String>('desc_$itemId'),
+                        initialValue: itemData.description,
+                        maxLines: 4,
+                        style: const TextStyle(color: Colors.white),
+                        onChanged: (String val) {
+                          context.read<MemoryGallerySettingBloc>().add(
+                            UpdateMemoryItemDescription(itemId, val),
+                          );
+                        },
+                        decoration: InputDecoration(
+                          filled: true,
+                          fillColor: Colors.white.withValues(alpha: 0.07),
+                          hintText: '설명을 입력해주세요',
+                          hintStyle: const TextStyle(color: Colors.white38),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: isDescriptionValid
+                                  ? AppColors.neonPurple
+                                  : Colors.red,
+                              width: 1.5,
+                            ),
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: isDescriptionValid
+                                  ? Colors.white24
+                                  : Colors.red,
+                              width: isDescriptionValid ? 1.0 : 1.5,
+                            ),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: isDescriptionValid
+                                  ? AppColors.neonPurple
+                                  : Colors.red,
+                              width: 1.5,
+                            ),
+                          ),
+                          errorText: !isDescriptionValid
+                              ? '설명은 최소 1글자 이상이어야 합니다.'
+                              : null,
+                        ),
+                      ),
+                      const SizedBox(height: 40),
+                    ],
+                  ),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 32,
+                  vertical: 16,
+                ),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF1A1A2E),
+                  border: Border(
+                    top: BorderSide(
+                      color: Colors.white.withValues(alpha: 0.1),
+                    ),
+                  ),
+                ),
+                child: Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          context.read<MemoryGallerySettingBloc>().add(
+                            RemoveMemoryItem(itemId),
+                          );
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.transparent,
+                          foregroundColor: Colors.redAccent,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            side: const BorderSide(
+                              color: Colors.redAccent,
+                              width: 1.5,
+                            ),
+                          ),
+                          elevation: 0,
+                        ),
+                        child: const Text(
+                          '삭제',
+                          style: TextStyle(
+                            fontFamily: 'WantedSans',
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.neonPurple,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          elevation: 0,
+                        ),
+                        child: const Text(
+                          '닫기',
+                          style: TextStyle(
+                            fontFamily: 'WantedSans',
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_edit_form.dart
@@ -28,10 +28,12 @@ class MemoryEditForm extends StatelessWidget {
         final bool isDescriptionValid = itemData.description.trim().isNotEmpty;
         final bool hasImage = itemData.imageFile != null;
 
-        return SafeArea(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
+        return Container(
+          color: const Color(0xFF1A1A2E),
+          child: SafeArea(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
               Expanded(
                 child: SingleChildScrollView(
                   padding: EdgeInsets.only(
@@ -321,7 +323,7 @@ class MemoryEditForm extends StatelessWidget {
                   vertical: 16,
                 ),
                 decoration: BoxDecoration(
-                  color: const Color(0xFF1A1A2E),
+                  color: Colors.transparent,
                   border: Border(
                     top: BorderSide(
                       color: Colors.white.withValues(alpha: 0.1),
@@ -389,8 +391,9 @@ class MemoryEditForm extends StatelessWidget {
               ),
             ],
           ),
-        );
-      },
-    );
-  }
+        ),
+      );
+    },
+  );
+}
 }

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_edit_form.dart
@@ -79,7 +79,10 @@ class MemoryEditForm extends StatelessWidget {
                       TextFormField(
                         key: ValueKey<String>('title_$itemId'),
                         initialValue: itemData.title,
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontFamily: 'WantedSans',
+                        ),
                         onChanged: (String val) {
                           context.read<MemoryGallerySettingBloc>().add(
                             UpdateMemoryItemTitle(itemId, val),
@@ -89,7 +92,11 @@ class MemoryEditForm extends StatelessWidget {
                           filled: true,
                           fillColor: Colors.white.withValues(alpha: 0.07),
                           hintText: '제목을 입력해주세요',
-                          hintStyle: const TextStyle(color: Colors.white38),
+                          hintStyle: const TextStyle(
+                            color: Colors.white38,
+                            fontFamily: 'WantedSans',
+                          ),
+                          errorStyle: const TextStyle(fontFamily: 'WantedSans'),
                           suffixIcon: itemData.title.isNotEmpty
                               ? IconButton(
                                   icon: const Icon(Icons.clear, size: 20),
@@ -195,7 +202,10 @@ class MemoryEditForm extends StatelessWidget {
                                 OutlinedButton.icon(
                                   onPressed: onPickImage,
                                   icon: const Icon(Icons.edit, size: 16),
-                                  label: const Text('수정'),
+                                  label: const Text(
+                                    '수정',
+                                    style: TextStyle(fontFamily: 'WantedSans'),
+                                  ),
                                   style: OutlinedButton.styleFrom(
                                     foregroundColor: AppColors.neonBlue,
                                     side: const BorderSide(
@@ -211,7 +221,10 @@ class MemoryEditForm extends StatelessWidget {
                                         .add(RemoveMemoryItemImage(itemId));
                                   },
                                   icon: const Icon(Icons.delete, size: 16),
-                                  label: const Text('삭제'),
+                                  label: const Text(
+                                    '삭제',
+                                    style: TextStyle(fontFamily: 'WantedSans'),
+                                  ),
                                   style: OutlinedButton.styleFrom(
                                     foregroundColor: Colors.redAccent,
                                     side: const BorderSide(
@@ -226,14 +239,20 @@ class MemoryEditForm extends StatelessWidget {
                       const SizedBox(height: 8),
                       const Text(
                         '- 부적절한 제목이나 이미지는 신고 대상이 될 수 있으며, 관련 책임은 등록 주체에게 있음을 알려드립니다.',
-                        style: TextStyle(fontSize: 14, color: Colors.grey),
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                          fontFamily: 'WantedSans',
+                        ),
                       ),
                       const SizedBox(height: 24),
                       const Text(
                         '설명',
                         style: TextStyle(
+                          fontFamily: 'WantedSans',
                           fontSize: 18,
                           fontWeight: FontWeight.bold,
+                          color: Colors.white,
                         ),
                       ),
                       const SizedBox(height: 8),
@@ -241,7 +260,10 @@ class MemoryEditForm extends StatelessWidget {
                         key: ValueKey<String>('desc_$itemId'),
                         initialValue: itemData.description,
                         maxLines: 4,
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontFamily: 'WantedSans',
+                        ),
                         onChanged: (String val) {
                           context.read<MemoryGallerySettingBloc>().add(
                             UpdateMemoryItemDescription(itemId, val),
@@ -251,7 +273,11 @@ class MemoryEditForm extends StatelessWidget {
                           filled: true,
                           fillColor: Colors.white.withValues(alpha: 0.07),
                           hintText: '설명을 입력해주세요',
-                          hintStyle: const TextStyle(color: Colors.white38),
+                          hintStyle: const TextStyle(
+                            color: Colors.white38,
+                            fontFamily: 'WantedSans',
+                          ),
+                          errorStyle: const TextStyle(fontFamily: 'WantedSans'),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(12),
                             borderSide: BorderSide(

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_gallery_bottom_bar.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_gallery_bottom_bar.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class MemoryGalleryBottomBar extends StatelessWidget {
+  const MemoryGalleryBottomBar({
+    super.key,
+    required this.itemCount,
+    required this.canSave,
+    required this.onComplete,
+  });
+
+  final int itemCount;
+  final bool canSave;
+  final VoidCallback onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 20.0),
+        decoration: BoxDecoration(
+          color: AppColors.darkBg,
+          border: Border(
+            top: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                const Icon(
+                  Icons.photo_library_rounded,
+                  size: 20,
+                  color: Colors.white70,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  '추억 목록 [ $itemCount개 ]',
+                  style: const TextStyle(
+                    fontFamily: 'WantedSans',
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+            const Spacer(),
+            const Tooltip(
+              triggerMode: TooltipTriggerMode.tap,
+              showDuration: Duration(seconds: 5),
+              margin: EdgeInsets.symmetric(horizontal: 24),
+              padding: EdgeInsets.all(12),
+              textStyle: TextStyle(
+                color: Colors.white,
+                fontSize: 13,
+                height: 1.5,
+              ),
+              message:
+                  '⚠️ 저장 완료 조건\n'
+                  '• 추억 최소 1개 이상 등록\n'
+                  '• 각 추억에 제목, 이미지, 설명 모두 입력',
+              child: Padding(
+                padding: EdgeInsets.only(right: 8),
+                child: Icon(Icons.info_outline, size: 20, color: Colors.grey),
+              ),
+            ),
+            const SizedBox(width: 12),
+            ElevatedButton(
+              onPressed: canSave ? onComplete : null,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.neonPurple,
+                foregroundColor: Colors.white,
+                disabledBackgroundColor: Colors.white12,
+                disabledForegroundColor: Colors.white38,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24.0,
+                  vertical: 18.0,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12.0),
+                ),
+                elevation: 0,
+              ),
+              child: const Text(
+                '추억 저장 완료',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_gallery_desktop_body.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_gallery_desktop_body.dart
@@ -1,0 +1,234 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reorderable_grid_view/reorderable_grid_view.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+import 'memory_desktop_card.dart';
+import 'memory_sort_button.dart';
+
+class MemoryGalleryDesktopBody extends StatelessWidget {
+  const MemoryGalleryDesktopBody({
+    super.key,
+    required this.galleryState,
+    required this.scrollController,
+    required this.onAddItem,
+    required this.onItemTap,
+    required this.isItemIncomplete,
+  });
+
+  final MemoryGallerySettingState galleryState;
+  final ScrollController scrollController;
+  final VoidCallback onAddItem;
+  final ValueChanged<MemoryGalleryItemData> onItemTap;
+  final bool Function(MemoryGalleryItemData) isItemIncomplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 40.0, right: 40.0, top: 24.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  MemorySortButton(
+                    state: galleryState,
+                    type: MemorySortType.createdAt,
+                    label: '생성순',
+                  ),
+                  MemorySortButton(
+                    state: galleryState,
+                    type: MemorySortType.titleKo,
+                    label: '제목 (한글)',
+                  ),
+                  MemorySortButton(
+                    state: galleryState,
+                    type: MemorySortType.titleEn,
+                    label: '제목 (영어)',
+                  ),
+                ],
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  ElevatedButton.icon(
+                    onPressed: onAddItem,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.neonBlue,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                    ),
+                    icon: const Icon(Icons.add, size: 18),
+                    label: const Text(
+                      '추가',
+                      style: TextStyle(fontFamily: 'PFStardust'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      context.read<MemoryGallerySettingBloc>().add(
+                        const RemoveAllMemoryItems(),
+                      );
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red.shade400,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                    ),
+                    icon: const Icon(Icons.delete_outline, size: 18),
+                    label: const Text(
+                      '초기화',
+                      style: TextStyle(fontFamily: 'PFStardust'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                final double availableWidth = constraints.maxWidth;
+                int crossAxisCount;
+                if (availableWidth >= 1400) {
+                  crossAxisCount = 5;
+                } else if (availableWidth >= 1100) {
+                  crossAxisCount = 4;
+                } else if (availableWidth >= 800) {
+                  crossAxisCount = 3;
+                } else {
+                  crossAxisCount = 2;
+                }
+
+                return Theme(
+                  data: ThemeData(canvasColor: Colors.transparent),
+                  child: ScrollConfiguration(
+                    behavior: ScrollConfiguration.of(context).copyWith(
+                      dragDevices: <PointerDeviceKind>{
+                        PointerDeviceKind.touch,
+                        PointerDeviceKind.mouse,
+                        PointerDeviceKind.trackpad,
+                      },
+                    ),
+                    child: Scrollbar(
+                      controller: scrollController,
+                      thumbVisibility: true,
+                      child: ReorderableGridView.builder(
+                        controller: scrollController,
+                        padding: const EdgeInsets.fromLTRB(4, 4, 20, 16),
+                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: crossAxisCount,
+                          crossAxisSpacing: 24,
+                          mainAxisSpacing: 24,
+                          childAspectRatio: 0.7,
+                        ),
+                        itemCount: galleryState.uiItems.length + 1,
+                        onReorder: (int oldIndex, int newIndex) {
+                          if (oldIndex == galleryState.uiItems.length ||
+                              newIndex == galleryState.uiItems.length) {
+                            return;
+                          }
+                          context.read<MemoryGallerySettingBloc>().add(
+                            ReorderMemoryItems(oldIndex, newIndex),
+                          );
+                        },
+                        itemBuilder: (BuildContext context, int index) {
+                          if (index == galleryState.uiItems.length) {
+                            return Container(
+                              key: const ValueKey<String>('add_card'),
+                              child: _DesktopAddCard(onPressed: onAddItem),
+                            );
+                          }
+                          final MemoryGalleryItemData item =
+                              galleryState.uiItems[index];
+                          return MemoryDesktopCard(
+                            key: ValueKey<int>(item.id),
+                            index: index,
+                            itemData: item,
+                            isIncomplete: isItemIncomplete(item),
+                            isSelected: galleryState.selectedItemId == item.id,
+                            isHovered: galleryState.hoveredItemId == item.id,
+                            onTap: () => onItemTap(item),
+                            onRemove: () {
+                              context.read<MemoryGallerySettingBloc>().add(
+                                RemoveMemoryItem(item.id),
+                              );
+                              context.read<MemoryGallerySettingBloc>().add(
+                                const ClearHoverMemoryItem(),
+                              );
+                            },
+                            onHoverEnter: () => context
+                                .read<MemoryGallerySettingBloc>()
+                                .add(HoverMemoryItem(item.id)),
+                            onHoverExit: () => context
+                                .read<MemoryGallerySettingBloc>()
+                                .add(const ClearHoverMemoryItem()),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DesktopAddCard extends StatelessWidget {
+  const _DesktopAddCard({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      style: OutlinedButton.styleFrom(
+        backgroundColor: AppColors.neonPurple.withValues(alpha: 0.05),
+        side: BorderSide(
+          color: AppColors.neonPurple.withValues(alpha: 0.4),
+          width: 1.5,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16.0),
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 36.0),
+      ),
+      onPressed: onPressed,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Icon(
+            Icons.add_circle_outline,
+            size: 28,
+            color: AppColors.neonPurple.withValues(alpha: 0.7),
+          ),
+          const SizedBox(width: 10),
+          Text(
+            '추억 추가하기',
+            style: TextStyle(
+              fontFamily: 'WantedSans',
+              color: AppColors.neonPurple.withValues(alpha: 0.8),
+              fontWeight: FontWeight.bold,
+              fontSize: 16,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_gallery_mobile_body.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_gallery_mobile_body.dart
@@ -1,0 +1,195 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+import 'memory_mobile_card.dart';
+import 'memory_sort_button.dart';
+
+class MemoryGalleryMobileBody extends StatelessWidget {
+  const MemoryGalleryMobileBody({
+    super.key,
+    required this.galleryState,
+    required this.scrollController,
+    required this.onAddItem,
+    required this.onItemTap,
+    required this.isItemIncomplete,
+  });
+
+  final MemoryGallerySettingState galleryState;
+  final ScrollController scrollController;
+  final VoidCallback onAddItem;
+  final ValueChanged<MemoryGalleryItemData> onItemTap;
+  final bool Function(MemoryGalleryItemData) isItemIncomplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  MemorySortButton(
+                    state: galleryState,
+                    type: MemorySortType.createdAt,
+                    label: '생성순',
+                    isMobile: true,
+                  ),
+                  MemorySortButton(
+                    state: galleryState,
+                    type: MemorySortType.titleKo,
+                    label: '제목 (한글)',
+                    isMobile: true,
+                  ),
+                  MemorySortButton(
+                    state: galleryState,
+                    type: MemorySortType.titleEn,
+                    label: '제목 (영어)',
+                    isMobile: true,
+                  ),
+                ],
+              ),
+              Row(
+                children: <Widget>[
+                  ElevatedButton.icon(
+                    onPressed: onAddItem,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.neonBlue,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                    ),
+                    icon: const Icon(Icons.add, size: 16),
+                    label: const Text(
+                      '추가',
+                      style: TextStyle(fontFamily: 'PFStardust'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      context.read<MemoryGallerySettingBloc>().add(
+                        const RemoveAllMemoryItems(),
+                      );
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red.shade400,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                    ),
+                    icon: const Icon(Icons.delete_outline, size: 16),
+                    label: const Text(
+                      '초기화',
+                      style: TextStyle(fontFamily: 'PFStardust'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        if (galleryState.uiItems.isEmpty)
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Icon(
+                    Icons.photo_library_outlined,
+                    size: 64,
+                    color: Colors.white24,
+                  ),
+                  const SizedBox(height: 16),
+                  const Text(
+                    '아직 등록된 추억이 없어요.',
+                    style: TextStyle(color: Colors.white38, fontSize: 15),
+                  ),
+                  const SizedBox(height: 20),
+                  ElevatedButton.icon(
+                    onPressed: onAddItem,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.neonBlue,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 12,
+                      ),
+                    ),
+                    icon: const Icon(Icons.add),
+                    label: const Text(
+                      '추억 추가하기',
+                      style: TextStyle(fontFamily: 'PFStardust'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          )
+        else
+          Expanded(
+            child: Theme(
+              data: ThemeData(canvasColor: Colors.transparent),
+              child: ScrollConfiguration(
+                behavior: ScrollConfiguration.of(context).copyWith(
+                  dragDevices: <PointerDeviceKind>{
+                    PointerDeviceKind.touch,
+                    PointerDeviceKind.mouse,
+                  },
+                ),
+                child: ReorderableListView.builder(
+                  scrollController: scrollController,
+                  scrollDirection: Axis.vertical,
+                  padding: const EdgeInsets.only(
+                    left: 16.0,
+                    right: 16.0,
+                    top: 8.0,
+                  ),
+                  itemCount: galleryState.uiItems.length,
+                  buildDefaultDragHandles: false,
+                  onReorder: (int oldIndex, int newIndex) {
+                    context.read<MemoryGallerySettingBloc>().add(
+                      ReorderMemoryItems(oldIndex, newIndex),
+                    );
+                  },
+                  itemBuilder: (BuildContext context, int index) {
+                    final MemoryGalleryItemData item =
+                        galleryState.uiItems[index];
+                    return MemoryMobileCard(
+                      key: ValueKey<int>(item.id),
+                      index: index,
+                      itemData: item,
+                      isIncomplete: isItemIncomplete(item),
+                      isSelected: galleryState.selectedItemId == item.id,
+                      onTap: () => onItemTap(item),
+                      onRemove: () => context
+                          .read<MemoryGallerySettingBloc>()
+                          .add(RemoveMemoryItem(item.id)),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_mobile_card.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_mobile_card.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+
+class MemoryMobileCard extends StatelessWidget {
+  const MemoryMobileCard({
+    required super.key,
+    required this.index,
+    required this.itemData,
+    required this.isIncomplete,
+    required this.isSelected,
+    required this.onTap,
+    required this.onRemove,
+  });
+
+  final int index;
+  final MemoryGalleryItemData itemData;
+  final bool isIncomplete;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16.0),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: <Widget>[
+          Material(
+            color: Colors.white.withValues(alpha: 0.05),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16.0),
+              side: BorderSide(
+                color: isSelected ? AppColors.neonPurple : Colors.white24,
+                width: isSelected ? 2.0 : 1.0,
+              ),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: onTap,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16.0,
+                  vertical: 16.0,
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    ReorderableDragStartListener(
+                      index: index,
+                      child: const Padding(
+                        padding: EdgeInsets.fromLTRB(0, 8, 12, 8),
+                        child: Icon(Icons.drag_handle, color: Colors.grey),
+                      ),
+                    ),
+                    Container(
+                      width: 80,
+                      height: 80,
+                      clipBehavior: Clip.antiAlias,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF8F9FA),
+                        borderRadius: BorderRadius.circular(12.0),
+                      ),
+                      child: itemData.imageFile != null
+                          ? Image.network(
+                              itemData.imageFile!.path,
+                              fit: BoxFit.cover,
+                            )
+                          : Icon(
+                              Icons.photo,
+                              size: 30,
+                              color: Colors.grey.shade300,
+                            ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          Text(
+                            itemData.title.isEmpty ? '제목 없음' : itemData.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontFamily: 'WantedSans',
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                              color: itemData.title.isEmpty
+                                  ? Colors.white38
+                                  : Colors.white,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            itemData.description.isEmpty
+                                ? '설명 없음'
+                                : itemData.description,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontFamily: 'WantedSans',
+                              fontSize: 13,
+                              color: itemData.description.isEmpty
+                                  ? Colors.white38
+                                  : Colors.white70,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(
+                        Icons.close,
+                        color: Colors.grey,
+                        size: 20,
+                      ),
+                      onPressed: onRemove,
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          if (isIncomplete)
+            Positioned(
+              top: -6,
+              left: -6,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.orange,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white, width: 2),
+                ),
+                padding: const EdgeInsets.all(4),
+                child: const Icon(
+                  Icons.priority_high,
+                  color: Colors.white,
+                  size: 16,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/memory_gallery/memory_sort_button.dart
+++ b/lib/features/addgift/presentation/widgets/memory_gallery/memory_sort_button.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/memory_gallery_setting/memory_gallery_setting_bloc.dart';
+
+class MemorySortButton extends StatelessWidget {
+  const MemorySortButton({
+    super.key,
+    required this.state,
+    required this.type,
+    required this.label,
+    this.isMobile = false,
+  });
+
+  final MemoryGallerySettingState state;
+  final MemorySortType type;
+  final String label;
+  final bool isMobile;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isSelected = state.sortType == type;
+
+    return InkWell(
+      onTap: () {
+        context.read<MemoryGallerySettingBloc>().add(SortMemoryItems(type));
+      },
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: isMobile ? 8 : 12,
+          vertical: isMobile ? 6 : 8,
+        ),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? AppColors.neonPurple.withValues(alpha: 0.2)
+              : Colors.white.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: isSelected
+                ? AppColors.neonPurple
+                : Colors.white.withValues(alpha: 0.2),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              label,
+              style: TextStyle(
+                fontFamily: 'WantedSans',
+                color: isSelected ? AppColors.neonPurple : Colors.white60,
+                fontSize: isMobile ? 12 : 14,
+                fontWeight: isSelected ? FontWeight.bold : FontWeight.w500,
+              ),
+            ),
+            if (isSelected) ...<Widget>[
+              const SizedBox(width: 4),
+              Icon(
+                state.isAscending ? Icons.arrow_upward : Icons.arrow_downward,
+                size: isMobile ? 14 : 16,
+                color: Colors.white,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_complete_button.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_complete_button.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class QuizCompleteButton extends StatelessWidget {
+  const QuizCompleteButton({
+    super.key,
+    required this.enabled,
+    required this.onPressed,
+    this.height = 60,
+  });
+
+  final bool enabled;
+  final VoidCallback onPressed;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: ElevatedButton(
+        onPressed: enabled ? onPressed : null,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF6DE1F1),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          elevation: 0,
+        ),
+        child: const Text(
+          '포장 완료',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_edit_form.dart
@@ -174,13 +174,14 @@ class _QuizEditFormState extends State<QuizEditForm> {
                     style: const TextStyle(
                       fontSize: 24,
                       fontWeight: FontWeight.bold,
+                      color: Colors.white,
                     ),
                   ),
                   const SizedBox(height: 24),
                   _buildSectionTitle('제목 (질문)'),
-                  TextField(
+                  _buildDarkTextField(
                     controller: _titleController,
-                    decoration: _inputDecoration('질문을 입력하세요'),
+                    hint: '질문을 입력하세요',
                   ),
                   const SizedBox(height: 16),
                   _buildSectionTitle('이미지 (선택)'),
@@ -216,15 +217,15 @@ class _QuizEditFormState extends State<QuizEditForm> {
                   ),
                   const SizedBox(height: 16),
                   _buildSectionTitle('설명'),
-                  TextField(
+                  _buildDarkTextField(
                     controller: _descController,
-                    decoration: _inputDecoration('문제에 대한 설명을 입력하세요'),
+                    hint: '문제에 대한 설명을 입력하세요',
                   ),
                   const SizedBox(height: 16),
                   _buildSectionTitle('힌트'),
-                  TextField(
+                  _buildDarkTextField(
                     controller: _hintController,
-                    decoration: _inputDecoration('문제에 대한 힌트를 입력하세요'),
+                    hint: '문제에 대한 힌트를 입력하세요',
                   ),
                   const SizedBox(height: 24),
 
@@ -237,13 +238,14 @@ class _QuizEditFormState extends State<QuizEditForm> {
                         padding: const EdgeInsets.only(bottom: 8.0),
                         child: Row(
                           children: <Widget>[
-                            Text('${entry.key + 1}. '),
+                            Text(
+                              '${entry.key + 1}. ',
+                              style: const TextStyle(color: Colors.white70),
+                            ),
                             Expanded(
-                              child: TextField(
+                              child: _buildDarkTextField(
                                 controller: entry.value,
-                                decoration: _inputDecoration(
-                                  '선택지 ${entry.key + 1}',
-                                ),
+                                hint: '선택지 ${entry.key + 1}',
                               ),
                             ),
                             IconButton(
@@ -288,6 +290,9 @@ class _QuizEditFormState extends State<QuizEditForm> {
                           _optionControllers.add(TextEditingController());
                         });
                       },
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColors.neonPurpleLight,
+                      ),
                       icon: const Icon(Icons.add),
                       label: const Text('선택지 추가'),
                     ),
@@ -299,8 +304,8 @@ class _QuizEditFormState extends State<QuizEditForm> {
                       children: List<Widget>.generate(
                         _optionControllers.length,
                         (int index) {
-                          final bool isSelected =
-                              _selectedMultipleChoiceAnswers.contains(index);
+                          final bool isSelected = _selectedMultipleChoiceAnswers
+                              .contains(index);
                           return ChoiceChip(
                             label: Text('${index + 1}번'),
                             selected: isSelected,
@@ -315,12 +320,12 @@ class _QuizEditFormState extends State<QuizEditForm> {
                             },
                             selectedColor: AppColors.neonPurple,
                             labelStyle: TextStyle(
-                              color:
-                                  isSelected ? Colors.white : Colors.white38,
+                              color: isSelected ? Colors.white : Colors.white38,
                               fontWeight: FontWeight.bold,
                             ),
-                            backgroundColor:
-                                Colors.white.withValues(alpha: 0.07),
+                            backgroundColor: Colors.white.withValues(
+                              alpha: 0.07,
+                            ),
                           );
                         },
                       ),
@@ -336,9 +341,9 @@ class _QuizEditFormState extends State<QuizEditForm> {
                         child: Row(
                           children: <Widget>[
                             Expanded(
-                              child: TextField(
+                              child: _buildDarkTextField(
                                 controller: entry.value,
-                                decoration: _inputDecoration('정답 형태 입력'),
+                                hint: '정답 형태 입력',
                               ),
                             ),
                             IconButton(
@@ -362,6 +367,9 @@ class _QuizEditFormState extends State<QuizEditForm> {
                           _answerControllers.add(TextEditingController());
                         });
                       },
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColors.neonPurpleLight,
+                      ),
                       icon: const Icon(Icons.add),
                       label: const Text('정답 형태 추가'),
                     ),
@@ -372,14 +380,12 @@ class _QuizEditFormState extends State<QuizEditForm> {
                         Expanded(
                           child: OutlinedButton(
                             style: OutlinedButton.styleFrom(
-                              backgroundColor:
-                                  _editingItem.answer.first == 'O'
-                                      ? AppColors.neonPurple
-                                      : Colors.white.withValues(alpha: 0.07),
-                              foregroundColor:
-                                  _editingItem.answer.first == 'O'
-                                      ? Colors.white
-                                      : Colors.white38,
+                              backgroundColor: _editingItem.answer.first == 'O'
+                                  ? AppColors.neonPurple
+                                  : Colors.white.withValues(alpha: 0.07),
+                              foregroundColor: _editingItem.answer.first == 'O'
+                                  ? Colors.white
+                                  : Colors.white38,
                             ),
                             onPressed: () => setState(() {
                               _editingItem.answer = <String>['O'];
@@ -397,14 +403,12 @@ class _QuizEditFormState extends State<QuizEditForm> {
                         Expanded(
                           child: OutlinedButton(
                             style: OutlinedButton.styleFrom(
-                              backgroundColor:
-                                  _editingItem.answer.first == 'X'
-                                      ? AppColors.neonPurple
-                                      : Colors.white.withValues(alpha: 0.07),
-                              foregroundColor:
-                                  _editingItem.answer.first == 'X'
-                                      ? Colors.white
-                                      : Colors.white38,
+                              backgroundColor: _editingItem.answer.first == 'X'
+                                  ? AppColors.neonPurple
+                                  : Colors.white.withValues(alpha: 0.07),
+                              foregroundColor: _editingItem.answer.first == 'X'
+                                  ? Colors.white
+                                  : Colors.white38,
                             ),
                             onPressed: () => setState(() {
                               _editingItem.answer = <String>['X'];
@@ -454,14 +458,31 @@ class _QuizEditFormState extends State<QuizEditForm> {
       padding: const EdgeInsets.only(bottom: 8.0),
       child: Text(
         title,
-        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        style: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
+          color: Colors.white70,
+        ),
       ),
+    );
+  }
+
+  Widget _buildDarkTextField({
+    required TextEditingController controller,
+    required String hint,
+  }) {
+    return TextField(
+      controller: controller,
+      style: const TextStyle(color: Colors.white),
+      cursorColor: AppColors.neonPurple,
+      decoration: _inputDecoration(hint),
     );
   }
 
   InputDecoration _inputDecoration(String hint) {
     return InputDecoration(
       hintText: hint,
+      hintStyle: const TextStyle(color: Colors.white38),
       filled: true,
       fillColor: Colors.white.withValues(alpha: 0.07),
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_edit_form.dart
@@ -1,0 +1,477 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../model/quiz_setting_models.dart';
+
+class QuizEditForm extends StatefulWidget {
+  final QuizItemData item;
+  final ValueChanged<QuizItemData> onSave;
+  final bool isDesktop;
+
+  const QuizEditForm({
+    super.key,
+    required this.item,
+    required this.onSave,
+    this.isDesktop = false,
+  });
+
+  @override
+  State<QuizEditForm> createState() => _QuizEditFormState();
+}
+
+class _QuizEditFormState extends State<QuizEditForm> {
+  late QuizItemData _editingItem;
+
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descController = TextEditingController();
+  final TextEditingController _hintController = TextEditingController();
+
+  // 객관식 답변들 컨트롤러 목록
+  final List<TextEditingController> _optionControllers =
+      <TextEditingController>[];
+  // 정답을 다루기 위한 컨트롤러들
+  final List<TextEditingController> _answerControllers =
+      <TextEditingController>[];
+
+  // 객관식 답변 다중 선택 인덱스
+  final Set<int> _selectedMultipleChoiceAnswers = <int>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _editingItem = widget.item;
+
+    _titleController.text = _editingItem.title;
+    _descController.text = _editingItem.description;
+    _hintController.text = _editingItem.hint;
+
+    if (_editingItem.type == QuizType.multipleChoice) {
+      if (_editingItem.options.isEmpty) {
+        _optionControllers.add(TextEditingController());
+        _optionControllers.add(TextEditingController());
+      } else {
+        for (final String opt in _editingItem.options) {
+          _optionControllers.add(TextEditingController(text: opt));
+        }
+      }
+      for (final String ans in _editingItem.answer) {
+        final int? idx = int.tryParse(ans);
+        if (idx != null) {
+          _selectedMultipleChoiceAnswers.add(idx);
+        } else {
+          // 기존 데이터 호환: 텍스트로 저장된 경우 인덱스를 찾음
+          final int foundIdx = _editingItem.options.indexOf(ans);
+          if (foundIdx != -1) {
+            _selectedMultipleChoiceAnswers.add(foundIdx);
+          }
+        }
+      }
+    } else if (_editingItem.type == QuizType.subjective) {
+      if (_editingItem.answer.isEmpty) {
+        _answerControllers.add(TextEditingController());
+      } else {
+        for (final String ans in _editingItem.answer) {
+          _answerControllers.add(TextEditingController(text: ans));
+        }
+      }
+    } else if (_editingItem.type == QuizType.ox) {
+      if (_editingItem.answer.isEmpty) {
+        _editingItem.answer = <String>['O'];
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descController.dispose();
+    _hintController.dispose();
+    for (final TextEditingController c in _optionControllers) {
+      c.dispose();
+    }
+    for (final TextEditingController c in _answerControllers) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  void _save() {
+    _editingItem.title = _titleController.text.trim();
+    _editingItem.description = _descController.text.trim();
+    _editingItem.hint = _hintController.text.trim();
+
+    if (_editingItem.type == QuizType.multipleChoice) {
+      _editingItem.options = _optionControllers
+          .map((TextEditingController c) => c.text.trim())
+          .where((String s) => s.isNotEmpty)
+          .toList();
+      _editingItem.answer = _selectedMultipleChoiceAnswers
+          .map((int idx) => idx.toString())
+          .toList();
+    } else if (_editingItem.type == QuizType.subjective) {
+      _editingItem.answer = _answerControllers
+          .map((TextEditingController c) => c.text.trim())
+          .where((String s) => s.isNotEmpty)
+          .toList();
+    }
+
+    widget.onSave(_editingItem);
+  }
+
+  Future<void> _pickImage() async {
+    final ImagePicker picker = ImagePicker();
+    final XFile? image = await picker.pickImage(source: ImageSource.gallery);
+    if (image != null) {
+      setState(() {
+        _editingItem.imageFile = image;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: widget.isDesktop
+          ? null
+          : BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.9),
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: AppColors.darkBg,
+        borderRadius: widget.isDesktop
+            ? BorderRadius.zero
+            : const BorderRadius.only(
+                topLeft: Radius.circular(24),
+                topRight: Radius.circular(24),
+              ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 24),
+              decoration: BoxDecoration(
+                color: Colors.white24,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    '${_editingItem.typeName} 문제 설정',
+                    style: const TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  _buildSectionTitle('제목 (질문)'),
+                  TextField(
+                    controller: _titleController,
+                    decoration: _inputDecoration('질문을 입력하세요'),
+                  ),
+                  const SizedBox(height: 16),
+                  _buildSectionTitle('이미지 (선택)'),
+                  GestureDetector(
+                    onTap: _pickImage,
+                    child: Container(
+                      height: 120,
+                      decoration: BoxDecoration(
+                        color: Colors.white12,
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: Colors.white.withValues(alpha: 0.15),
+                        ),
+                        image: _editingItem.imageFile != null
+                            ? DecorationImage(
+                                image: NetworkImage(
+                                  _editingItem.imageFile!.path,
+                                ),
+                                fit: BoxFit.cover,
+                              )
+                            : null,
+                      ),
+                      child: _editingItem.imageFile == null
+                          ? const Center(
+                              child: Icon(
+                                Icons.add_photo_alternate,
+                                size: 40,
+                                color: Colors.white24,
+                              ),
+                            )
+                          : null,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  _buildSectionTitle('설명'),
+                  TextField(
+                    controller: _descController,
+                    decoration: _inputDecoration('문제에 대한 설명을 입력하세요'),
+                  ),
+                  const SizedBox(height: 16),
+                  _buildSectionTitle('힌트'),
+                  TextField(
+                    controller: _hintController,
+                    decoration: _inputDecoration('문제에 대한 힌트를 입력하세요'),
+                  ),
+                  const SizedBox(height: 24),
+
+                  if (_editingItem.type == QuizType.multipleChoice) ...<Widget>[
+                    _buildSectionTitle('선택지'),
+                    ..._optionControllers.asMap().entries.map((
+                      MapEntry<int, TextEditingController> entry,
+                    ) {
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 8.0),
+                        child: Row(
+                          children: <Widget>[
+                            Text('${entry.key + 1}. '),
+                            Expanded(
+                              child: TextField(
+                                controller: entry.value,
+                                decoration: _inputDecoration(
+                                  '선택지 ${entry.key + 1}',
+                                ),
+                              ),
+                            ),
+                            IconButton(
+                              icon: const Icon(
+                                Icons.remove_circle,
+                                color: Colors.red,
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  _optionControllers.removeAt(entry.key);
+                                  // 선택된 인덱스들 갱신 로직
+                                  if (_selectedMultipleChoiceAnswers.contains(
+                                    entry.key,
+                                  )) {
+                                    _selectedMultipleChoiceAnswers.remove(
+                                      entry.key,
+                                    );
+                                  }
+                                  final Set<int> newAnswers = <int>{};
+                                  for (final int ans
+                                      in _selectedMultipleChoiceAnswers) {
+                                    if (ans > entry.key) {
+                                      newAnswers.add(ans - 1);
+                                    } else {
+                                      newAnswers.add(ans);
+                                    }
+                                  }
+                                  _selectedMultipleChoiceAnswers.clear();
+                                  _selectedMultipleChoiceAnswers.addAll(
+                                    newAnswers,
+                                  );
+                                });
+                              },
+                            ),
+                          ],
+                        ),
+                      );
+                    }),
+                    TextButton.icon(
+                      onPressed: () {
+                        setState(() {
+                          _optionControllers.add(TextEditingController());
+                        });
+                      },
+                      icon: const Icon(Icons.add),
+                      label: const Text('선택지 추가'),
+                    ),
+                    const SizedBox(height: 16),
+                    _buildSectionTitle('정답 선택 (복수 선택 가능)'),
+                    Wrap(
+                      spacing: 8.0,
+                      runSpacing: 8.0,
+                      children: List<Widget>.generate(
+                        _optionControllers.length,
+                        (int index) {
+                          final bool isSelected =
+                              _selectedMultipleChoiceAnswers.contains(index);
+                          return ChoiceChip(
+                            label: Text('${index + 1}번'),
+                            selected: isSelected,
+                            onSelected: (bool selected) {
+                              setState(() {
+                                if (selected) {
+                                  _selectedMultipleChoiceAnswers.add(index);
+                                } else {
+                                  _selectedMultipleChoiceAnswers.remove(index);
+                                }
+                              });
+                            },
+                            selectedColor: AppColors.neonPurple,
+                            labelStyle: TextStyle(
+                              color:
+                                  isSelected ? Colors.white : Colors.white38,
+                              fontWeight: FontWeight.bold,
+                            ),
+                            backgroundColor:
+                                Colors.white.withValues(alpha: 0.07),
+                          );
+                        },
+                      ),
+                    ),
+                  ] else if (_editingItem.type ==
+                      QuizType.subjective) ...<Widget>[
+                    _buildSectionTitle('정답 목록 (유사 답변 포함)'),
+                    ..._answerControllers.asMap().entries.map((
+                      MapEntry<int, TextEditingController> entry,
+                    ) {
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 8.0),
+                        child: Row(
+                          children: <Widget>[
+                            Expanded(
+                              child: TextField(
+                                controller: entry.value,
+                                decoration: _inputDecoration('정답 형태 입력'),
+                              ),
+                            ),
+                            IconButton(
+                              icon: const Icon(
+                                Icons.remove_circle,
+                                color: Colors.red,
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  _answerControllers.removeAt(entry.key);
+                                });
+                              },
+                            ),
+                          ],
+                        ),
+                      );
+                    }),
+                    TextButton.icon(
+                      onPressed: () {
+                        setState(() {
+                          _answerControllers.add(TextEditingController());
+                        });
+                      },
+                      icon: const Icon(Icons.add),
+                      label: const Text('정답 형태 추가'),
+                    ),
+                  ] else if (_editingItem.type == QuizType.ox) ...<Widget>[
+                    _buildSectionTitle('정답'),
+                    Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: OutlinedButton(
+                            style: OutlinedButton.styleFrom(
+                              backgroundColor:
+                                  _editingItem.answer.first == 'O'
+                                      ? AppColors.neonPurple
+                                      : Colors.white.withValues(alpha: 0.07),
+                              foregroundColor:
+                                  _editingItem.answer.first == 'O'
+                                      ? Colors.white
+                                      : Colors.white38,
+                            ),
+                            onPressed: () => setState(() {
+                              _editingItem.answer = <String>['O'];
+                            }),
+                            child: const Text(
+                              'O',
+                              style: TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: OutlinedButton(
+                            style: OutlinedButton.styleFrom(
+                              backgroundColor:
+                                  _editingItem.answer.first == 'X'
+                                      ? AppColors.neonPurple
+                                      : Colors.white.withValues(alpha: 0.07),
+                              foregroundColor:
+                                  _editingItem.answer.first == 'X'
+                                      ? Colors.white
+                                      : Colors.white38,
+                            ),
+                            onPressed: () => setState(() {
+                              _editingItem.answer = <String>['X'];
+                            }),
+                            child: const Text(
+                              'X',
+                              style: TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                  const SizedBox(height: 40),
+                ],
+              ),
+            ),
+          ),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: _save,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.neonPurple,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: const Text(
+                '저장 완료',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8.0),
+      child: Text(
+        title,
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  InputDecoration _inputDecoration(String hint) {
+    return InputDecoration(
+      hintText: hint,
+      filled: true,
+      fillColor: Colors.white.withValues(alpha: 0.07),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: AppColors.neonPurple),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_edit_form.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_edit_form.dart
@@ -8,12 +8,15 @@ class QuizEditForm extends StatefulWidget {
   final QuizItemData item;
   final ValueChanged<QuizItemData> onSave;
   final bool isDesktop;
+  // 이미지 업로드 한도(10개) 도달 여부 — true이면 이미 이미지가 없는 항목에서 피커 비활성화
+  final bool isImageLimitReached;
 
   const QuizEditForm({
     super.key,
     required this.item,
     required this.onSave,
     this.isDesktop = false,
+    this.isImageLimitReached = false,
   });
 
   @override
@@ -120,6 +123,8 @@ class _QuizEditFormState extends State<QuizEditForm> {
   }
 
   Future<void> _pickImage() async {
+    // 이미지가 없는 상태에서 한도에 도달했으면 피커를 열지 않음
+    if (_editingItem.imageFile == null && widget.isImageLimitReached) return;
     final ImagePicker picker = ImagePicker();
     final XFile? image = await picker.pickImage(source: ImageSource.gallery);
     if (image != null) {

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_items_section.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_items_section.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../application/quiz_setting/quiz_setting_bloc.dart';
+import '../../../model/quiz_setting_models.dart';
+import 'quiz_list_item.dart';
+
+class QuizItemsSection extends StatelessWidget {
+  const QuizItemsSection({
+    super.key,
+    required this.isMobile,
+    required this.quizState,
+    required this.onAddItem,
+    required this.onRemoveAllItems,
+    required this.onReorder,
+    required this.onRemoveItem,
+    required this.onTapItem,
+  });
+
+  final bool isMobile;
+  final QuizSettingState quizState;
+  final VoidCallback onAddItem;
+  final VoidCallback onRemoveAllItems;
+  final ReorderCallback onReorder;
+  final ValueChanged<String> onRemoveItem;
+  final ValueChanged<QuizItemData> onTapItem;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: <Widget>[
+            ElevatedButton(
+              onPressed: onAddItem,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.neonPurple,
+                foregroundColor: Colors.white,
+                elevation: 0,
+              ),
+              child: const Text('추가'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: onRemoveAllItems,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.redAccent,
+                foregroundColor: Colors.white,
+                elevation: 0,
+              ),
+              child: const Text('모두 제거'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        Expanded(
+          child: Container(
+            width: double.infinity,
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.15),
+                width: 1,
+              ),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: quizState.uiItems.isEmpty
+                ? const Center(
+                    child: Text(
+                      '추가 버튼을 눌러 문제를 생성해보세요.',
+                      style: TextStyle(color: Colors.white38),
+                    ),
+                  )
+                : ReorderableListView.builder(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: quizState.uiItems.length,
+                    onReorder: onReorder,
+                    buildDefaultDragHandles: false,
+                    proxyDecorator:
+                        (Widget child, int index, Animation<double> animation) {
+                          return Material(
+                            color: Colors.transparent,
+                            elevation: 0,
+                            child: child,
+                          );
+                        },
+                    itemBuilder: (BuildContext context, int index) {
+                      final QuizItemData item = quizState.uiItems[index];
+                      return QuizListItem(
+                        key: ValueKey<String>(item.id),
+                        item: item,
+                        index: index,
+                        onRemove: () => onRemoveItem(item.id),
+                        onTap: () => onTapItem(item),
+                      );
+                    },
+                  ),
+          ),
+        ),
+        if (isMobile) const SizedBox(height: 24),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_list_item.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_list_item.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../model/quiz_setting_models.dart';
+
+class QuizListItem extends StatelessWidget {
+  const QuizListItem({
+    super.key,
+    required this.item,
+    required this.index,
+    required this.onRemove,
+    required this.onTap,
+  });
+
+  final QuizItemData item;
+  final int index;
+  final VoidCallback onRemove;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: ValueKey<String>(item.id),
+      color: Colors.white.withValues(alpha: 0.05),
+      margin: const EdgeInsets.only(bottom: 16),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        side: BorderSide(color: Colors.white.withValues(alpha: 0.15)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        leading: ReorderableDragStartListener(
+          index: index,
+          child: const Icon(Icons.menu, color: Colors.white38),
+        ),
+        title: Row(
+          children: <Widget>[
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: AppColors.neonPurple.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                item.typeName,
+                style: const TextStyle(
+                  color: AppColors.neonPurple,
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Q. ${item.title.isEmpty ? '(제목 없음)' : item.title}',
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 8.0),
+          child: Text(
+            'A. ${item.answer.isEmpty ? '(정답 없음)' : item.answer.join(", ")}',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(color: Colors.white54),
+          ),
+        ),
+        trailing: IconButton(
+          icon: const Icon(Icons.close, size: 24, color: Colors.red),
+          onPressed: onRemove,
+        ),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_mobile_bottom_bar.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_mobile_bottom_bar.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import 'quiz_complete_button.dart';
+
+class QuizMobileBottomBar extends StatelessWidget {
+  const QuizMobileBottomBar({
+    super.key,
+    required this.isSubmitting,
+    required this.onShowSettings,
+    required this.onComplete,
+  });
+
+  final bool isSubmitting;
+  final VoidCallback onShowSettings;
+  final VoidCallback onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.07),
+          border: const Border(top: BorderSide(color: Colors.white12)),
+        ),
+        child: Row(
+          children: <Widget>[
+            InkWell(
+              onTap: onShowSettings,
+              borderRadius: BorderRadius.circular(16),
+              child: Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.07),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    width: 2,
+                  ),
+                ),
+                child: const Icon(Icons.settings, color: Colors.white60),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: QuizCompleteButton(
+                enabled: !isSubmitting,
+                onPressed: onComplete,
+                height: 56,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_settings_panel.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_settings_panel.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../../application/quiz_setting/quiz_setting_bloc.dart';
+import '../../../model/quiz_setting_models.dart';
+
+class QuizSettingsPanel extends StatelessWidget {
+  const QuizSettingsPanel({
+    super.key,
+    required this.quizState,
+    required this.isMobile,
+    required this.successRewardNameController,
+    required this.failRewardNameController,
+    required this.onPickSuccessRewardImage,
+    required this.onPickFailRewardImage,
+  });
+
+  final QuizSettingState quizState;
+  final bool isMobile;
+  final TextEditingController successRewardNameController;
+  final TextEditingController failRewardNameController;
+  final VoidCallback onPickSuccessRewardImage;
+  final VoidCallback onPickFailRewardImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (!isMobile) const SizedBox(height: 24),
+        Container(
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  const Text(
+                    '맞춘 문제가 ',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                  DropdownButtonHideUnderline(
+                    child: DropdownButton<int>(
+                      value: quizState.uiItems.isEmpty
+                          ? 1
+                          : (quizState.successReward.requiredCount! >
+                                    quizState.uiItems.length
+                                ? quizState.uiItems.length
+                                : quizState.successReward.requiredCount),
+                      alignment: Alignment.center,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                      icon: const Icon(
+                        Icons.keyboard_arrow_down,
+                        size: 20,
+                        color: Colors.white38,
+                      ),
+                      items: List<int>.generate(
+                            quizState.uiItems.isEmpty
+                                ? 1
+                                : quizState.uiItems.length,
+                            (int index) => index + 1,
+                          )
+                          .map(
+                            (int value) => DropdownMenuItem<int>(
+                              value: value,
+                              child: Text('$value개'),
+                            ),
+                          )
+                          .toList(),
+                      onChanged: quizState.uiItems.isEmpty
+                          ? null
+                          : (int? newVal) {
+                              if (newVal != null) {
+                                context.read<QuizSettingBloc>().add(
+                                  UpdateSuccessReward(
+                                    QuizRewardData(
+                                      requiredCount: newVal,
+                                      itemName:
+                                          quizState.successReward.itemName,
+                                      imageFile:
+                                          quizState.successReward.imageFile,
+                                    ),
+                                  ),
+                                );
+                              }
+                            },
+                    ),
+                  ),
+                  const Text(
+                    ' 일 때',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _buildRewardImagePicker(
+                    isSuccess: true,
+                    imageFile: quizState.successReward.imageFile,
+                    onTap: onPickSuccessRewardImage,
+                  ),
+                  const SizedBox(height: 16),
+                  _buildRewardNameInput(
+                    controller: successRewardNameController,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        Container(
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                '그 외 (실패 보상 등)',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _buildRewardImagePicker(
+                    isSuccess: false,
+                    imageFile: quizState.failReward.imageFile,
+                    onTap: onPickFailRewardImage,
+                  ),
+                  const SizedBox(height: 16),
+                  _buildRewardNameInput(
+                    controller: failRewardNameController,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 40),
+        const Text(
+          'BGM 설정',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.white.withValues(alpha: 0.12),
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                '메인 BGM :',
+                style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      decoration: BoxDecoration(
+                        color: Colors.white12,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: DropdownButtonHideUnderline(
+                        child: DropdownButton<String>(
+                          value: quizState.selectedBgm,
+                          isExpanded: true,
+                          dropdownColor: const Color(0xFF1A1A1A),
+                          style: const TextStyle(color: Colors.white),
+                          iconEnabledColor: Colors.white38,
+                          onChanged: (String? val) {
+                            if (val != null) {
+                              context.read<QuizSettingBloc>().add(
+                                UpdateQuizBgm(val),
+                              );
+                            }
+                          },
+                          items: <String>['신나는 생일', '잔잔한 음악', '우리의 추억']
+                              .map(
+                                (String value) => DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(
+                                    value,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: Colors.white12,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Icon(Icons.play_arrow, color: Colors.white38),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRewardImagePicker({
+    required bool isSuccess,
+    required XFile? imageFile,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        height: 80,
+        decoration: BoxDecoration(
+          color: Colors.white12,
+          borderRadius: BorderRadius.circular(8),
+          image: imageFile != null
+              ? DecorationImage(
+                  image: NetworkImage(imageFile.path),
+                  fit: BoxFit.cover,
+                )
+              : null,
+        ),
+        child: imageFile == null
+            ? const Center(
+                child: Text(
+                  '물품 사진',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              )
+            : null,
+      ),
+    );
+  }
+
+  Widget _buildRewardNameInput({required TextEditingController controller}) {
+    return TextFormField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: '물품 이름',
+        filled: true,
+        fillColor: Colors.white12,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide.none,
+        ),
+      ),
+      style: const TextStyle(color: Colors.white),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/quiz/quiz_title_bar.dart
+++ b/lib/features/addgift/presentation/widgets/quiz/quiz_title_bar.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class QuizTitleBar extends StatelessWidget {
+  const QuizTitleBar({
+    super.key,
+    required this.userNameController,
+    required this.subTitleController,
+    this.suffixLabel = '문제 맞추기',
+  });
+
+  final TextEditingController userNameController;
+  final TextEditingController subTitleController;
+  final String suffixLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 100,
+          child: TextFormField(
+            controller: userNameController,
+            decoration: InputDecoration(
+              hintText: '닉네임',
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 12,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(
+                  color: AppColors.neonPurple,
+                  width: 1.5,
+                ),
+              ),
+            ),
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+        const SizedBox(width: 8),
+        const Text('님의', style: TextStyle(fontSize: 16, color: Colors.white70)),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 120,
+          child: TextFormField(
+            controller: subTitleController,
+            decoration: InputDecoration(
+              hintText: '서브 타이틀',
+              hintStyle: const TextStyle(color: Colors.white38),
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 12,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.3),
+                  width: 1,
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  width: 1,
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(
+                  color: AppColors.neonPurple,
+                  width: 1.5,
+                ),
+              ),
+            ),
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          suffixLabel,
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_bottom_button.dart
+++ b/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_bottom_button.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class ReceiverNameBottomButton extends StatelessWidget {
+  const ReceiverNameBottomButton({
+    super.key,
+    required this.nameController,
+    required this.onNext,
+  });
+
+  final TextEditingController nameController;
+  final ValueChanged<String> onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: ValueListenableBuilder<TextEditingValue>(
+        valueListenable: nameController,
+        builder: (BuildContext context, TextEditingValue value, Widget? child) {
+          final bool isNameEmpty = value.text.trim().isEmpty;
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+            child: SizedBox(
+              height: 60,
+              child: ElevatedButton(
+                onPressed: isNameEmpty ? null : () => onNext(value.text.trim()),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.neonPurple,
+                  foregroundColor: Colors.white,
+                  disabledBackgroundColor: Colors.white12,
+                  disabledForegroundColor: Colors.white38,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16.0),
+                  ),
+                  elevation: 0,
+                ),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Text(
+                      '다음',
+                      style: TextStyle(
+                        fontFamily: 'WantedSans',
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    SizedBox(width: 8),
+                    Icon(Icons.arrow_forward_rounded, size: 22),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_desktop_layout.dart
+++ b/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_desktop_layout.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import 'receiver_name_input_field.dart';
+
+class ReceiverNameDesktopLayout extends StatelessWidget {
+  const ReceiverNameDesktopLayout({super.key, required this.nameController});
+
+  final TextEditingController nameController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 64.0,
+              vertical: 48.0,
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  '선물 받는 분의',
+                  style: TextStyle(
+                    fontFamily: 'PFStardustS',
+                    fontSize: 36,
+                    color: Colors.white.withValues(alpha: 0.9),
+                    height: 1.4,
+                  ),
+                ),
+                const Text(
+                  '닉네임을 알려주세요',
+                  style: TextStyle(
+                    fontFamily: 'PFStardustS',
+                    fontSize: 36,
+                    color: AppColors.neonPurple,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '받는 분의 닉네임으로 선물이 포장됩니다.',
+                  style: TextStyle(
+                    fontFamily: 'WantedSans',
+                    fontSize: 15,
+                    color: Colors.white38,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(
+          child: Center(
+            child: SizedBox(
+              width: 400,
+              child: ReceiverNameInputField(controller: nameController),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_input_field.dart
+++ b/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_input_field.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class ReceiverNameInputField extends StatelessWidget {
+  const ReceiverNameInputField({super.key, required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      textAlign: TextAlign.center,
+      controller: controller,
+      style: const TextStyle(
+        fontFamily: 'WantedSans',
+        fontSize: 22,
+        fontWeight: FontWeight.bold,
+        color: Colors.white,
+      ),
+      decoration: InputDecoration(
+        hintText: '닉네임 입력',
+        hintStyle: const TextStyle(
+          fontFamily: 'WantedSans',
+          color: Colors.white38,
+          fontSize: 18,
+        ),
+        filled: true,
+        fillColor: Colors.white.withValues(alpha: 0.07),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 20.0,
+          vertical: 24.0,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16.0),
+          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2)),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16.0),
+          borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.2)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16.0),
+          borderSide: const BorderSide(color: AppColors.neonPurple, width: 2.0),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_mobile_layout.dart
+++ b/lib/features/addgift/presentation/widgets/receiver_name/receiver_name_mobile_layout.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import 'receiver_name_input_field.dart';
+
+class ReceiverNameMobileLayout extends StatelessWidget {
+  const ReceiverNameMobileLayout({
+    super.key,
+    required this.isMobile,
+    required this.nameController,
+  });
+
+  final bool isMobile;
+  final TextEditingController nameController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: isMobile ? 24.0 : 48.0,
+        vertical: 32.0,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          const SizedBox(height: 24),
+          Text(
+            '선물 받는 분의\n닉네임을 알려주세요',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontFamily: 'PFStardustS',
+              fontSize: isMobile ? 24 : 30,
+              color: Colors.white,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 40),
+          Center(
+            child: SizedBox(
+              width: isMobile ? double.infinity : 400,
+              child: ReceiverNameInputField(controller: nameController),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/addgift/presentation/widgets/step_indicator.dart
+++ b/lib/features/addgift/presentation/widgets/step_indicator.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/app_colors.dart';
+
+class StepIndicator extends StatelessWidget {
+  const StepIndicator({super.key, required this.activeStep});
+
+  /// 현재 활성화된 단계 (1, 2, 3 중 하나).
+  /// 해당 번호까지의 원과 연결선이 활성 색상으로 표시됩니다.
+  final int activeStep;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 20.0),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          _buildCircle(isActive: activeStep >= 1, number: '1'),
+          _buildLine(isActive: activeStep >= 2),
+          _buildCircle(isActive: activeStep >= 2, number: '2'),
+          _buildLine(isActive: activeStep >= 3),
+          _buildCircle(isActive: activeStep >= 3, number: '3'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCircle({required bool isActive, required String number}) {
+    return Container(
+      width: 28,
+      height: 28,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: isActive ? AppColors.neonPurple : Colors.white12,
+        border: isActive ? null : Border.all(color: Colors.white24),
+      ),
+      child: Center(
+        child: Text(
+          number,
+          style: TextStyle(
+            fontFamily: 'WantedSans',
+            color: isActive ? Colors.white : Colors.white38,
+            fontSize: 13,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLine({required bool isActive}) {
+    return Container(
+      width: 16,
+      height: 2,
+      color: isActive
+          ? AppColors.neonPurple.withValues(alpha: 0.5)
+          : Colors.white12,
+    );
+  }
+}

--- a/lib/features/addgift/repository/addgift_api.dart
+++ b/lib/features/addgift/repository/addgift_api.dart
@@ -15,4 +15,12 @@ abstract class AddGiftApi {
   Future<HttpResponse<dynamic>> createGift(
     @Body() Map<String, dynamic> request,
   );
+
+  // 이미지 업로드 (type: MEMORY | GIFT | QUIZ)
+  @POST('/api/images')
+  @MultiPart()
+  Future<HttpResponse<dynamic>> uploadImage(
+    @Query('type') String type,
+    @Part(name: 'file') MultipartFile file,
+  );
 }

--- a/lib/features/addgift/repository/addgift_api.g.dart
+++ b/lib/features/addgift/repository/addgift_api.g.dart
@@ -42,6 +42,37 @@ class _AddGiftApi implements AddGiftApi {
     return httpResponse;
   }
 
+  @override
+  Future<HttpResponse<dynamic>> uploadImage(
+    String type,
+    MultipartFile file,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'type': type};
+    final _headers = <String, dynamic>{};
+    final _data = FormData();
+    _data.files.add(MapEntry('file', file));
+    final _options = _setStreamType<HttpResponse<dynamic>>(
+      Options(
+            method: 'POST',
+            headers: _headers,
+            extra: _extra,
+            contentType: 'multipart/form-data',
+          )
+          .compose(
+            _dio.options,
+            '/api/images',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch(_options);
+    final _value = _result.data;
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		132B4AC2DD90CD5CC815CD83 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F309F411FCFE6250951A9CB /* Pods_RunnerTests.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		8FB5DE6E5A23B16ACC895C71 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 506211ECE59143A185F2A35F /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,7 +66,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* gifo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "gifo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* gifo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = gifo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +78,16 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		506211ECE59143A185F2A35F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CF833993D9C23EC1DB12633 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		725C33772ECCB3F3C5DDD262 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		842C3A0E7EC2C450BBD63B6B /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		9F309F411FCFE6250951A9CB /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A7DFF26319866D7D37F47898 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		C72CABC4BC1C0804E464C861 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		C93D91E5CF943ABF6FBFC369 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				132B4AC2DD90CD5CC815CD83 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,12 +103,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8FB5DE6E5A23B16ACC895C71 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0AE945DFC446AA49E35C50EC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C72CABC4BC1C0804E464C861 /* Pods-Runner.debug.xcconfig */,
+				A7DFF26319866D7D37F47898 /* Pods-Runner.release.xcconfig */,
+				C93D91E5CF943ABF6FBFC369 /* Pods-Runner.profile.xcconfig */,
+				842C3A0E7EC2C450BBD63B6B /* Pods-RunnerTests.debug.xcconfig */,
+				5CF833993D9C23EC1DB12633 /* Pods-RunnerTests.release.xcconfig */,
+				725C33772ECCB3F3C5DDD262 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C80D6294CF71000263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -125,6 +151,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				0AE945DFC446AA49E35C50EC /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,6 +202,8 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				506211ECE59143A185F2A35F /* Pods_Runner.framework */,
+				9F309F411FCFE6250951A9CB /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				C12AA3B3175247B268AD3F3A /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				073EB60B9E6CCA282EE37C5D /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				DD16B768BD1A171B758873BE /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -291,6 +323,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		073EB60B9E6CCA282EE37C5D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -328,6 +382,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		C12AA3B3175247B268AD3F3A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DD16B768BD1A171B758873BE /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 842C3A0E7EC2C450BBD63B6B /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5CF833993D9C23EC1DB12633 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 725C33772ECCB3F3C5DDD262 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
## Summary

- AddGift 선물 포장 플로우(8단계)의 대형 View 파일들을 기능별 소형 위젯으로 분리
- GiftPackagingBloc을 통한 상태 관리로 전환하여 View에서 직접 상태를 보유하던 구조 제거
- 이미지 업로드 및 제출 로딩 오버레이(`PackagingLoadingOverlay`) 추가
- JSON 직렬화 필드명 수정 및 Freezed 모델 regeneration

## Changed Views → Extracted Widgets

| View | 추출된 위젯 |
|---|---|
| `GachaSettingView` | `GachaCapsuleItem`, `GachaItemEditForm`, `GachaItemsSection`, `GachaMobileBottomBar`, `GachaSettingsPanel`, `GachaTitleBar` |
| `QuizSettingView` | `QuizEditForm`, `QuizListItem`, `QuizItemsSection`, `QuizMobileBottomBar`, `QuizSettingsPanel`, `QuizTitleBar`, `QuizCompleteButton` |
| `MemoryGallerySettingView` | `MemoryDesktopCard`, `MemoryMobileCard`, `MemoryEditForm`, `MemoryGalleryBottomBar`, `MemoryGalleryDesktopBody`, `MemoryGalleryMobileBody`, `MemorySortButton` |
| `DirectOpenSettingView` | `BeforeOpenCard`, `AfterOpenCard`, `DirectOpenTitleBar`, `DirectOpenContentSection`, `DirectOpenSettingsSection`, `DirectOpenMobileBottomBar`, `DirectOpenCompleteButton`, `DirectOpenStepIndicator` |
| `ReceiverNameView` | `ReceiverNameInputField`, `ReceiverNameBottomButton`, `ReceiverNameDesktopLayout`, `ReceiverNameMobileLayout` |
| `MemoryDecisionView` | `MemoryDecisionMainText`, `MemoryDecisionSelectionButton`, `MemoryDecisionButtonsColumn` |
| `GiftDeliveryMethodView` | `GiftDeliveryMainText`, `GiftDeliveryOptionCard`, `GiftDeliveryOptionsGrid` |

## Test Plan

- [ ] 선물 포장 8단계 플로우 전체 진행 확인
- [ ] 가챠/퀴즈/메모리/다이렉트오픈 각 설정 화면 정상 렌더링 확인
- [ ] 모바일/데스크탑 레이아웃 분기 정상 동작 확인
- [ ] 이미지 업로드 및 제출 시 로딩 오버레이 표시 확인
- [ ] 선물 포장 완료 후 서버 전송 및 공유 URL 생성 확인